### PR TITLE
Fix string cmd empty value bug

### DIFF
--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -212,3 +212,12 @@ func getRandomHex(buf []byte) []byte {
 
 	return buf
 }
+
+func getKeys(args [][]byte) [][]byte {
+	var keys [][]byte
+	for i := 0; i < len(args); i += 2 {
+		keys = append(keys, args[i])
+	}
+
+	return keys
+}

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -185,11 +185,7 @@ func session(arg0 interface{}, args [][]byte) (Session, error) {
 	if s == nil {
 		return nil, errors.New("invalid session")
 	}
-	for i, v := range args {
-		if len(v) == 0 {
-			return nil, errors.Errorf("args[%d] is nil", i)
-		}
-	}
+
 	return s, nil
 }
 
@@ -211,13 +207,4 @@ func getRandomHex(buf []byte) []byte {
 	}
 
 	return buf
-}
-
-func getKeys(args [][]byte) [][]byte {
-	var keys [][]byte
-	for i := 0; i < len(args); i += 2 {
-		keys = append(keys, args[i])
-	}
-
-	return keys
 }

--- a/pkg/service/misc.go
+++ b/pkg/service/misc.go
@@ -19,7 +19,7 @@ func (h *Handler) Auth(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	c, err := checkConn(arg0, nil)
+	c, err := checkConn(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}

--- a/pkg/service/repl.go
+++ b/pkg/service/repl.go
@@ -208,11 +208,7 @@ func checkConn(arg0 interface{}, args [][]byte) (*conn, error) {
 	if s == nil {
 		return nil, errors.New("invalid connection")
 	}
-	for i, v := range args {
-		if len(v) == 0 {
-			return nil, errors.Errorf("args[%d] is nil", i)
-		}
-	}
+
 	return s, nil
 }
 

--- a/pkg/service/string.go
+++ b/pkg/service/string.go
@@ -50,7 +50,8 @@ func (h *Handler) Set(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	s, err := session(arg0, args)
+	keys := getKeys(args)
+	s, err := session(arg0, keys)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -68,7 +69,8 @@ func (h *Handler) PSetEX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	s, err := session(arg0, args)
+	keys := args[0:1]
+	s, err := session(arg0, keys)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -86,7 +88,8 @@ func (h *Handler) SetEX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	s, err := session(arg0, args)
+	keys := args[0:1]
+	s, err := session(arg0, keys)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -104,7 +107,8 @@ func (h *Handler) SetNX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	s, err := session(arg0, args)
+	keys := args[0:1]
+	s, err := session(arg0, keys)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -122,7 +126,8 @@ func (h *Handler) GetSet(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	s, err := session(arg0, args)
+	keys := args[0:1]
+	s, err := session(arg0, keys)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -266,7 +271,8 @@ func (h *Handler) MSet(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
 	}
 
-	s, err := session(arg0, args)
+	keys := getKeys(args)
+	s, err := session(arg0, keys)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -284,7 +290,8 @@ func (h *Handler) MSetNX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
 	}
 
-	s, err := session(arg0, args)
+	keys := getKeys(args)
+	s, err := session(arg0, keys)
 	if err != nil {
 		return toRespError(err)
 	}

--- a/pkg/service/string.go
+++ b/pkg/service/string.go
@@ -50,8 +50,7 @@ func (h *Handler) Set(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	keys := getKeys(args)
-	s, err := session(arg0, keys)
+	s, err := session(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -69,8 +68,7 @@ func (h *Handler) PSetEX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	keys := args[0:1]
-	s, err := session(arg0, keys)
+	s, err := session(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -88,8 +86,7 @@ func (h *Handler) SetEX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	keys := args[0:1]
-	s, err := session(arg0, keys)
+	s, err := session(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -107,8 +104,7 @@ func (h *Handler) SetNX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	keys := args[0:1]
-	s, err := session(arg0, keys)
+	s, err := session(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -126,8 +122,7 @@ func (h *Handler) GetSet(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	keys := args[0:1]
-	s, err := session(arg0, keys)
+	s, err := session(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -271,8 +266,7 @@ func (h *Handler) MSet(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
 	}
 
-	keys := getKeys(args)
-	s, err := session(arg0, keys)
+	s, err := session(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}
@@ -290,8 +284,7 @@ func (h *Handler) MSetNX(arg0 interface{}, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
 	}
 
-	keys := getKeys(args)
-	s, err := session(arg0, keys)
+	s, err := session(arg0, args)
 	if err != nil {
 		return toRespError(err)
 	}

--- a/pkg/service/string_test.go
+++ b/pkg/service/string_test.go
@@ -41,6 +41,11 @@ func (s *testServiceSuite) TestXGetSet(c *C) {
 	s.checkInt(c, 1, "incr", k)
 	s.checkString(c, "1", "getset", k, 0)
 	s.checkString(c, "0", "get", k)
+	s.checkInt(c, 1, "del", k)
+	s.checkOK(c, "set", k, "hello")
+	s.checkString(c, "hello", "getset", k, "")
+	s.checkString(c, "", "getset", k, "hello")
+	s.checkString(c, "hello", "get", k)
 }
 
 func (s *testServiceSuite) TestXIncr(c *C) {
@@ -70,6 +75,8 @@ func (s *testServiceSuite) TestXSet(c *C) {
 	k := randomKey(c)
 	s.checkOK(c, "set", k, "hello")
 	s.checkString(c, "hello", "get", k)
+	s.checkOK(c, "set", k, "")
+	s.checkString(c, "", "get", k)
 }
 
 func (s *testServiceSuite) TestXPSetEX(c *C) {
@@ -78,6 +85,8 @@ func (s *testServiceSuite) TestXPSetEX(c *C) {
 	s.checkOK(c, "psetex", k, 2000*1000, "world")
 	s.checkString(c, "world", "get", k)
 	s.checkIntApprox(c, 2000, 5, "ttl", k)
+	s.checkOK(c, "psetex", k, 1000*1000, "")
+	s.checkString(c, "", "get", k)
 }
 
 func (s *testServiceSuite) TestXSetEX(c *C) {
@@ -86,6 +95,8 @@ func (s *testServiceSuite) TestXSetEX(c *C) {
 	s.checkOK(c, "setex", k, 2000, "world")
 	s.checkString(c, "world", "get", k)
 	s.checkIntApprox(c, 2000, 5, "ttl", k)
+	s.checkOK(c, "setex", k, 1000, "")
+	s.checkString(c, "", "get", k)
 }
 
 func (s *testServiceSuite) TestXSetNX(c *C) {
@@ -94,6 +105,9 @@ func (s *testServiceSuite) TestXSetNX(c *C) {
 	s.checkInt(c, 0, "setnx", k, "world")
 	s.checkString(c, "hello", "get", k)
 	s.checkInt(c, -1, "ttl", k)
+	s.checkInt(c, 1, "del", k)
+	s.checkInt(c, 1, "setnx", k, "")
+	s.checkString(c, "", "get", k)
 }
 
 func (s *testServiceSuite) TestXSetRange(c *C) {
@@ -127,6 +141,11 @@ func (s *testServiceSuite) TestXMSet(c *C) {
 	s.checkString(c, "3", "get", k+"3")
 	s.checkOK(c, "mset", k, 100, k, 1000)
 	s.checkString(c, "1000", "get", k)
+	s.checkOK(c, "mset", k+"11", "", k+"12", "", k+"13", "", k+"14", "")
+	s.checkString(c, "", "get", k+"11")
+	s.checkString(c, "", "get", k+"12")
+	s.checkString(c, "", "get", k+"13")
+	s.checkString(c, "", "get", k+"14")
 }
 
 func (s *testServiceSuite) TestMSetNX(c *C) {
@@ -136,12 +155,15 @@ func (s *testServiceSuite) TestMSetNX(c *C) {
 	s.checkInt(c, 1, "del", k)
 	s.checkInt(c, 1, "msetnx", k, "1", k, "2")
 	s.checkString(c, "2", "get", k)
+	s.checkInt(c, 1, "msetnx", "3", "", "4", "")
+	s.checkString(c, "", "get", "3")
+	s.checkString(c, "", "get", "4")
 }
 
 func (s *testServiceSuite) TestMGet(c *C) {
 	k := randomKey(c)
-	s.checkOK(c, "mset", k, 0, k+"1", 1, k+"2", 2, k+"3", 3)
-	a := s.checkBytesArray(c, "mget", k, k+"1", k+"2", k+"3")
-	c.Assert(a, HasLen, 4)
-	c.Assert(a, DeepEquals, [][]byte{[]byte("0"), []byte("1"), []byte("2"), []byte("3")})
+	s.checkOK(c, "mset", k, 0, k+"1", 1, k+"2", 2, k+"3", 3, k+"4", "")
+	a := s.checkBytesArray(c, "mget", k, k+"1", k+"2", k+"3", k+"4")
+	c.Assert(a, HasLen, 5)
+	c.Assert(a, DeepEquals, [][]byte{[]byte("0"), []byte("1"), []byte("2"), []byte("3"), []byte("")})
 }

--- a/pkg/store/format.go
+++ b/pkg/store/format.go
@@ -204,9 +204,6 @@ func parseArgument(arg interface{}, ref interface{}) error {
 		default:
 			return errors.Errorf("expect %v, but got %v", reflect.TypeOf(*x), reflect.TypeOf(y))
 		}
-		if len(*x) == 0 {
-			return errors.Errorf("byte slice length = 0")
-		}
 	case *string:
 		switch y := arg.(type) {
 		case []byte:
@@ -215,9 +212,6 @@ func parseArgument(arg interface{}, ref interface{}) error {
 			*x = y
 		default:
 			return errors.Errorf("expect %v, but got %v", reflect.TypeOf(*x), reflect.TypeOf(y))
-		}
-		if len(*x) == 0 {
-			return errors.Errorf("string length = 0")
 		}
 	}
 	return nil

--- a/pkg/store/keys_test.go
+++ b/pkg/store/keys_test.go
@@ -270,7 +270,7 @@ func (s *testStoreSuite) TestRestore(c *C) {
 	s.zrestore(c, 0, "key", 3000, "z0", 100, "z1", 1000)
 	s.lrestore(c, 0, "key", 4000, "l0", "l1", "l2")
 	s.srestore(c, 0, "key", 10, "a", "b", "c", "d")
-	sleepms(20)
+	sleepms(30)
 	s.kexists(c, 0, "key", 0)
 	s.checkEmpty(c)
 }

--- a/pkg/store/rowbuf.go
+++ b/pkg/store/rowbuf.go
@@ -57,7 +57,7 @@ func (r *BufReader) ReadVarbytes() ([]byte, error) {
 	if n < 0 || n > maxVarbytesLen {
 		return nil, errors.Trace(ErrVarbytesLen)
 	} else if n == 0 {
-		return nil, nil
+		return []byte{}, nil
 	}
 	return r.ReadBytes(int(n))
 }

--- a/pkg/store/string.go
+++ b/pkg/store/string.go
@@ -17,6 +17,53 @@ type stringRow struct {
 	Value []byte
 }
 
+func adjustIndex(index int64, min, max int64) int64 {
+	if index >= 0 {
+		return index + min
+	} else {
+		return index + max
+	}
+}
+
+func minIntValue(v1, v2 int64) int64 {
+	if v1 < v2 {
+		return v1
+	} else {
+		return v2
+	}
+}
+
+func maxIntValue(v1, v2 int64) int64 {
+	if v1 < v2 {
+		return v2
+	} else {
+		return v1
+	}
+}
+
+func getKeys(args [][]byte) [][]byte {
+	var keys [][]byte
+	for i := 0; i < len(args); i += 2 {
+		keys = append(keys, args[i])
+	}
+
+	return keys
+}
+
+func checkKeysEmpty(keys [][]byte) bool {
+	if len(keys) == 0 {
+		return true
+	}
+
+	for _, v := range keys {
+		if len(v) == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 func newStringRow(db uint32, key []byte) *stringRow {
 	o := &stringRow{}
 	o.lazyInit(db, key, newStoreRowHelper(db, key, StringCode))
@@ -114,6 +161,10 @@ func (s *Store) Append(db uint32, args ...interface{}) (int64, error) {
 		}
 	}
 
+	if len(key) == 0 {
+		return 0, errArguments("empty key found")
+	}
+
 	if err := s.acquire(); err != nil {
 		return 0, err
 	}
@@ -154,6 +205,10 @@ func (s *Store) Set(db uint32, args ...interface{}) error {
 		}
 	}
 
+	if len(key) == 0 {
+		return errArguments("empty key found")
+	}
+
 	if err := s.acquire(); err != nil {
 		return err
 	}
@@ -185,9 +240,15 @@ func (s *Store) PSetEX(db uint32, args ...interface{}) error {
 			return errArguments("parse args[%d] failed, %s", i, err)
 		}
 	}
+
+	if len(key) == 0 {
+		return errArguments("empty key found")
+	}
+
 	if ttlms == 0 {
 		return errArguments("invalid ttlms = %d", ttlms)
 	}
+
 	expireat := uint64(0)
 	if v, ok := TTLmsToExpireAt(ttlms); ok && v > 0 {
 		expireat = v
@@ -231,9 +292,15 @@ func (s *Store) SetEX(db uint32, args ...interface{}) error {
 			return errArguments("parse args[%d] failed, %s", i, err)
 		}
 	}
+
+	if len(key) == 0 {
+		return errArguments("empty key found")
+	}
+
 	if ttls == 0 {
 		return errArguments("invalid ttls = %d", ttls)
 	}
+
 	expireat := uint64(0)
 	if v, ok := TTLsToExpireAt(ttls); ok && v > 0 {
 		expireat = v
@@ -277,6 +344,10 @@ func (s *Store) SetNX(db uint32, args ...interface{}) (int64, error) {
 		}
 	}
 
+	if len(key) == 0 {
+		return 0, errArguments("empty key found")
+	}
+
 	if err := s.acquire(); err != nil {
 		return 0, err
 	}
@@ -307,6 +378,10 @@ func (s *Store) GetSet(db uint32, args ...interface{}) ([]byte, error) {
 		if err := parseArgument(args[i], ref); err != nil {
 			return nil, errArguments("parse args[%d] failed, %s", i, err)
 		}
+	}
+
+	if len(key) == 0 {
+		return nil, errArguments("empty key found")
 	}
 
 	if err := s.acquire(); err != nil {
@@ -626,6 +701,11 @@ func (s *Store) MSet(db uint32, args ...interface{}) error {
 		}
 	}
 
+	keys := getKeys(pairs)
+	if checkKeysEmpty(keys) {
+		return errArguments("empty key found")
+	}
+
 	if err := s.acquire(); err != nil {
 		return err
 	}
@@ -662,6 +742,11 @@ func (s *Store) MSetNX(db uint32, args ...interface{}) (int64, error) {
 		if err := parseArgument(args[i], &pairs[i]); err != nil {
 			return 0, errArguments("parse args[%d] failed, %s", i, err)
 		}
+	}
+
+	keys := getKeys(pairs)
+	if checkKeysEmpty(keys) {
+		return 0, errArguments("empty key found")
 	}
 
 	if err := s.acquire(); err != nil {
@@ -816,30 +901,6 @@ func (s *Store) GetRange(db uint32, args ...interface{}) ([]byte, error) {
 		}
 	}
 	return nil, nil
-}
-
-func adjustIndex(index int64, min, max int64) int64 {
-	if index >= 0 {
-		return index + min
-	} else {
-		return index + max
-	}
-}
-
-func minIntValue(v1, v2 int64) int64 {
-	if v1 < v2 {
-		return v1
-	} else {
-		return v2
-	}
-}
-
-func maxIntValue(v1, v2 int64) int64 {
-	if v1 < v2 {
-		return v2
-	} else {
-		return v1
-	}
 }
 
 // STRLEN key

--- a/pkg/store/string.go
+++ b/pkg/store/string.go
@@ -92,14 +92,9 @@ func (s *Store) Get(db uint32, args ...interface{}) ([]byte, error) {
 	if err != nil || o == nil {
 		return nil, err
 	} else {
-		ok, err := o.LoadDataValue(s)
+		_, err := o.LoadDataValue(s)
 		if err != nil {
 			return nil, err
-		}
-
-		// Notice: fix a bug, when value is ""
-		if ok && o.Value == nil {
-			o.Value = []byte{}
 		}
 
 		return o.Value, nil
@@ -326,14 +321,9 @@ func (s *Store) GetSet(db uint32, args ...interface{}) ([]byte, error) {
 
 	bt := engine.NewBatch()
 	if o != nil {
-		ok, err := o.LoadDataValue(s)
+		_, err := o.LoadDataValue(s)
 		if err != nil {
 			return nil, err
-		}
-
-		// Notice: fix a bug, when value is ""
-		if ok && o.Value == nil {
-			o.Value = []byte{}
 		}
 
 		if o.ExpireAt != 0 {
@@ -734,14 +724,9 @@ func (s *Store) MGet(db uint32, args ...interface{}) ([][]byte, error) {
 			return nil, err
 		}
 		if o != nil {
-			ok, err := o.LoadDataValue(s)
+			_, err := o.LoadDataValue(s)
 			if err != nil {
 				return nil, err
-			}
-
-			// Notice: fix a bug, when value is ""
-			if ok && o.Value == nil {
-				o.Value = []byte{}
 			}
 
 			values[i] = o.Value

--- a/pkg/store/string.go
+++ b/pkg/store/string.go
@@ -92,10 +92,16 @@ func (s *Store) Get(db uint32, args ...interface{}) ([]byte, error) {
 	if err != nil || o == nil {
 		return nil, err
 	} else {
-		_, err := o.LoadDataValue(s)
+		ok, err := o.LoadDataValue(s)
 		if err != nil {
 			return nil, err
 		}
+
+		// Notice: fix a bug, when value is ""
+		if ok && o.Value == nil {
+			o.Value = []byte{}
+		}
+
 		return o.Value, nil
 	}
 }
@@ -320,10 +326,16 @@ func (s *Store) GetSet(db uint32, args ...interface{}) ([]byte, error) {
 
 	bt := engine.NewBatch()
 	if o != nil {
-		_, err := o.LoadDataValue(s)
+		ok, err := o.LoadDataValue(s)
 		if err != nil {
 			return nil, err
 		}
+
+		// Notice: fix a bug, when value is ""
+		if ok && o.Value == nil {
+			o.Value = []byte{}
+		}
+
 		if o.ExpireAt != 0 {
 			o.ExpireAt = 0
 			bt.Set(o.MetaKey(), o.MetaValue())
@@ -722,10 +734,16 @@ func (s *Store) MGet(db uint32, args ...interface{}) ([][]byte, error) {
 			return nil, err
 		}
 		if o != nil {
-			_, err := o.LoadDataValue(s)
+			ok, err := o.LoadDataValue(s)
 			if err != nil {
 				return nil, err
 			}
+
+			// Notice: fix a bug, when value is ""
+			if ok && o.Value == nil {
+				o.Value = []byte{}
+			}
+
 			values[i] = o.Value
 		}
 	}


### PR DESCRIPTION
Fix empty value get/set bug. 
For example,
set a "" should return "OK"
get a should return ""
also include mget/mset cmd