### PR TITLE
Remove iconvert

### DIFF
--- a/pkg/service/hash.go
+++ b/pkg/service/hash.go
@@ -14,7 +14,7 @@ func HGetAllCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if a, err := s.Store().HGetAll(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().HGetAll(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -31,7 +31,7 @@ func HDelCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().HDel(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().HDel(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -44,7 +44,7 @@ func HExistsCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if x, err := s.Store().HExists(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().HExists(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -57,7 +57,7 @@ func HGetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if b, err := s.Store().HGet(s.DB(), iconvert(args)...); err != nil {
+	if b, err := s.Store().HGet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(b), nil
@@ -70,7 +70,7 @@ func HLenCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if n, err := s.Store().HLen(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().HLen(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -83,7 +83,7 @@ func HIncrByCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if v, err := s.Store().HIncrBy(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().HIncrBy(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -96,7 +96,7 @@ func HIncrByFloatCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if v, err := s.Store().HIncrByFloat(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().HIncrByFloat(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytesWithString(store.FormatFloatString(v)), nil
@@ -109,7 +109,7 @@ func HKeysCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if a, err := s.Store().HKeys(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().HKeys(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -126,7 +126,7 @@ func HValsCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if a, err := s.Store().HVals(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().HVals(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -143,7 +143,7 @@ func HSetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if x, err := s.Store().HSet(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().HSet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -156,7 +156,7 @@ func HSetNXCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if x, err := s.Store().HSetNX(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().HSetNX(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -169,7 +169,7 @@ func HMSetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 1 && mod 2 = 1", len(args))
 	}
 
-	if err := s.Store().HMSet(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().HMSet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -182,7 +182,7 @@ func HMGetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if a, err := s.Store().HMGet(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().HMGet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()

--- a/pkg/service/keys.go
+++ b/pkg/service/keys.go
@@ -33,7 +33,7 @@ func DelCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 1", len(args))
 	}
 
-	if n, err := s.Store().Del(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().Del(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -46,7 +46,7 @@ func DumpCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if x, err := s.Store().Dump(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().Dump(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else if dump, err := rdb.EncodeDump(x); err != nil {
 		return toRespError(err)
@@ -61,7 +61,7 @@ func TypeCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if c, err := s.Store().Type(s.DB(), iconvert(args)...); err != nil {
+	if c, err := s.Store().Type(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString(c.String()), nil
@@ -74,7 +74,7 @@ func ExistsCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if x, err := s.Store().Exists(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().Exists(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -87,7 +87,7 @@ func TTLCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if x, err := s.Store().TTL(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().TTL(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -100,7 +100,7 @@ func PTTLCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if x, err := s.Store().PTTL(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().PTTL(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -113,7 +113,7 @@ func PersistCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if x, err := s.Store().Persist(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().Persist(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -126,7 +126,7 @@ func ExpireCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if x, err := s.Store().Expire(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().Expire(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -139,7 +139,7 @@ func PExpireCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if x, err := s.Store().PExpire(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().PExpire(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -152,7 +152,7 @@ func ExpireAtCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if x, err := s.Store().ExpireAt(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().ExpireAt(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -165,7 +165,7 @@ func PExpireAtCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if x, err := s.Store().PExpireAt(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().PExpireAt(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -178,7 +178,7 @@ func RestoreCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if err := s.Store().Restore(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().Restore(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil

--- a/pkg/service/list.go
+++ b/pkg/service/list.go
@@ -11,7 +11,7 @@ func LIndexCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if v, err := s.Store().LIndex(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().LIndex(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(v), nil
@@ -24,7 +24,7 @@ func LLenCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if n, err := s.Store().LLen(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().LLen(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -37,7 +37,7 @@ func LRangeCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if a, err := s.Store().LRange(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().LRange(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -54,7 +54,7 @@ func LSetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if err := s.Store().LSet(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().LSet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -67,7 +67,7 @@ func LTrimCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if err := s.Store().LTrim(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().LTrim(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -80,7 +80,7 @@ func LPopCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if v, err := s.Store().LPop(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().LPop(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(v), nil
@@ -93,7 +93,7 @@ func RPopCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if v, err := s.Store().RPop(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().RPop(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(v), nil
@@ -106,7 +106,7 @@ func LPushCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().LPush(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().LPush(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -119,7 +119,7 @@ func LPushXCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().LPushX(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().LPushX(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -132,7 +132,7 @@ func RPushCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().RPush(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().RPush(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -145,7 +145,7 @@ func RPushXCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().RPushX(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().RPushX(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil

--- a/pkg/service/repl.go
+++ b/pkg/service/repl.go
@@ -133,22 +133,11 @@ func (h *Handler) respEncodeStoreForward(f *store.Forward) ([]byte, error) {
 	buf.WriteString(fmt.Sprintf("$%d\r\n%s\r\n", len(f.Op), f.Op))
 
 	for _, arg := range f.Args {
-		switch t := arg.(type) {
-		case []byte:
-			buf.WriteString(fmt.Sprintf("$%d\r\n", len(t)))
-			buf.Write(t)
-			buf.WriteString("\r\n")
-		case string:
-			buf.WriteString(fmt.Sprintf("$%d\r\n", len(t)))
-			buf.WriteString(t)
-			buf.WriteString("\r\n")
-		default:
-			str := fmt.Sprintf("%v", t)
-			buf.WriteString(fmt.Sprintf("$%d\r\n", len(str)))
-			buf.WriteString(str)
-			buf.WriteString("\r\n")
-		}
+		buf.WriteString(fmt.Sprintf("$%d\r\n", len(arg)))
+		buf.Write(arg)
+		buf.WriteString("\r\n")
 	}
+
 	return buf.Bytes(), nil
 }
 

--- a/pkg/service/set.go
+++ b/pkg/service/set.go
@@ -11,7 +11,7 @@ func SAddCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().SAdd(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SAdd(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -24,7 +24,7 @@ func SCardCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if n, err := s.Store().SCard(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SCard(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -37,7 +37,7 @@ func SIsMemberCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if x, err := s.Store().SIsMember(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().SIsMember(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -50,7 +50,7 @@ func SMembersCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if a, err := s.Store().SMembers(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().SMembers(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -67,7 +67,7 @@ func SPopCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if v, err := s.Store().SPop(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().SPop(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(v), nil
@@ -80,7 +80,7 @@ func SRandMemberCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1 or 2", len(args))
 	}
 
-	if a, err := s.Store().SRandMember(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().SRandMember(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -97,7 +97,7 @@ func SRemCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().SRem(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SRem(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil

--- a/pkg/service/slots.go
+++ b/pkg/service/slots.go
@@ -14,7 +14,7 @@ func SlotsRestoreCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 0 && mod 3 == 0", len(args))
 	}
 
-	if err := s.Store().SlotsRestore(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().SlotsRestore(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -27,7 +27,7 @@ func SlotsMgrtSlotCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 4", len(args))
 	}
 
-	if n, err := s.Store().SlotsMgrtSlot(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SlotsMgrtSlot(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -47,7 +47,7 @@ func SlotsMgrtTagSlotCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 4", len(args))
 	}
 
-	if n, err := s.Store().SlotsMgrtTagSlot(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SlotsMgrtTagSlot(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -67,7 +67,7 @@ func SlotsMgrtOneCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 4", len(args))
 	}
 
-	if n, err := s.Store().SlotsMgrtOne(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SlotsMgrtOne(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -80,7 +80,7 @@ func SlotsMgrtTagOneCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 4", len(args))
 	}
 
-	if n, err := s.Store().SlotsMgrtTagOne(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SlotsMgrtTagOne(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -93,7 +93,7 @@ func SlotsInfoCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect <= 2", len(args))
 	}
 
-	if m, err := s.Store().SlotsInfo(s.DB(), iconvert(args)...); err != nil {
+	if m, err := s.Store().SlotsInfo(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()

--- a/pkg/service/string.go
+++ b/pkg/service/string.go
@@ -14,7 +14,7 @@ func GetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if b, err := s.Store().Get(s.DB(), iconvert(args)...); err != nil {
+	if b, err := s.Store().Get(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(b), nil
@@ -27,7 +27,7 @@ func AppendCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if n, err := s.Store().Append(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().Append(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -40,7 +40,7 @@ func SetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if err := s.Store().Set(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().Set(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -53,7 +53,7 @@ func PSetEXCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if err := s.Store().PSetEX(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().PSetEX(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -66,7 +66,7 @@ func SetEXCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if err := s.Store().SetEX(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().SetEX(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -79,7 +79,7 @@ func SetNXCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if n, err := s.Store().SetNX(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().SetNX(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -92,7 +92,7 @@ func GetSetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if b, err := s.Store().GetSet(s.DB(), iconvert(args)...); err != nil {
+	if b, err := s.Store().GetSet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(b), nil
@@ -105,7 +105,7 @@ func IncrCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if v, err := s.Store().Incr(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().Incr(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -118,7 +118,7 @@ func IncrByCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if v, err := s.Store().IncrBy(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().IncrBy(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -131,7 +131,7 @@ func DecrCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if v, err := s.Store().Decr(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().Decr(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -144,7 +144,7 @@ func DecrByCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if v, err := s.Store().DecrBy(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().DecrBy(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -157,7 +157,7 @@ func IncrByFloatCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if v, err := s.Store().IncrByFloat(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().IncrByFloat(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytesWithString(store.FormatFloatString(v)), nil
@@ -170,7 +170,7 @@ func SetBitCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if x, err := s.Store().SetBit(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().SetBit(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -183,7 +183,7 @@ func SetRangeCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if x, err := s.Store().SetRange(s.DB(), iconvert(args)...); err != nil {
+	if x, err := s.Store().SetRange(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(x), nil
@@ -196,7 +196,7 @@ func MSetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
 	}
 
-	if err := s.Store().MSet(s.DB(), iconvert(args)...); err != nil {
+	if err := s.Store().MSet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewString("OK"), nil
@@ -209,7 +209,7 @@ func MSetNXCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
 	}
 
-	if n, err := s.Store().MSetNX(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().MSetNX(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -222,7 +222,7 @@ func MGetCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 1", len(args))
 	}
 
-	if a, err := s.Store().MGet(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().MGet(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()

--- a/pkg/service/sync.go
+++ b/pkg/service/sync.go
@@ -519,13 +519,13 @@ func (h *Handler) doSyncRDB(c *conn, size int64) error {
 				db, key, value := entry.DB, entry.Key, entry.Value
 				ttlms := int64(0)
 				if entry.ExpireAt != 0 {
-					if v, ok := store.ExpireAtToTTLms(entry.ExpireAt); ok && v > 0 {
+					if v, ok := store.ExpireAtToTTLms(int64(entry.ExpireAt)); ok && v > 0 {
 						ttlms = v
 					} else {
 						ttlms = 1
 					}
 				}
-				if err := c.Store().SlotsRestore(db, key, ttlms, value); err != nil {
+				if err := c.Store().SlotsRestore(db, [][]byte{key, store.FormatInt(ttlms), value}); err != nil {
 					errs <- err
 					return
 				}

--- a/pkg/service/zset.go
+++ b/pkg/service/zset.go
@@ -14,7 +14,7 @@ func ZGetAllCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if a, err := s.Store().ZGetAll(s.DB(), iconvert(args)...); err != nil {
+	if a, err := s.Store().ZGetAll(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -31,7 +31,7 @@ func ZCardCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 1", len(args))
 	}
 
-	if n, err := s.Store().ZCard(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().ZCard(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -44,7 +44,7 @@ func ZAddCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect != 1 && mod 2 = 1", len(args))
 	}
 
-	if n, err := s.Store().ZAdd(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().ZAdd(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -57,7 +57,7 @@ func ZRemCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 2", len(args))
 	}
 
-	if n, err := s.Store().ZRem(s.DB(), iconvert(args)...); err != nil {
+	if n, err := s.Store().ZRem(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(n), nil
@@ -70,7 +70,7 @@ func ZScoreCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 2", len(args))
 	}
 
-	if v, ok, err := s.Store().ZScore(s.DB(), iconvert(args)...); err != nil {
+	if v, ok, err := s.Store().ZScore(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else if !ok {
 		return redis.NewBulkBytes(nil), nil
@@ -85,7 +85,7 @@ func ZIncrByCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if v, err := s.Store().ZIncrBy(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZIncrBy(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewBulkBytes(store.FormatFloat(v)), nil
@@ -98,7 +98,7 @@ func ZCountCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if v, err := s.Store().ZCount(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZCount(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -111,7 +111,7 @@ func ZLexCountCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3", len(args))
 	}
 
-	if v, err := s.Store().ZLexCount(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZLexCount(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -124,7 +124,7 @@ func ZRangeCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3 or 4", len(args))
 	}
 
-	if ay, err := s.Store().ZRange(s.DB(), iconvert(args)...); err != nil {
+	if ay, err := s.Store().ZRange(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -141,7 +141,7 @@ func ZRevRangeCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3 or 4", len(args))
 	}
 
-	if ay, err := s.Store().ZRevRange(s.DB(), iconvert(args)...); err != nil {
+	if ay, err := s.Store().ZRevRange(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -158,7 +158,7 @@ func ZRangeByLexCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3 or 6", len(args))
 	}
 
-	if ay, err := s.Store().ZRangeByLex(s.DB(), iconvert(args)...); err != nil {
+	if ay, err := s.Store().ZRangeByLex(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -175,7 +175,7 @@ func ZRevRangeByLexCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect = 3 or 6", len(args))
 	}
 
-	if ay, err := s.Store().ZRevRangeByLex(s.DB(), iconvert(args)...); err != nil {
+	if ay, err := s.Store().ZRevRangeByLex(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -192,7 +192,7 @@ func ZRangeByScoreCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 3", len(args))
 	}
 
-	if ay, err := s.Store().ZRangeByScore(s.DB(), iconvert(args)...); err != nil {
+	if ay, err := s.Store().ZRangeByScore(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -209,7 +209,7 @@ func ZRevRangeByScoreCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect >= 3", len(args))
 	}
 
-	if ay, err := s.Store().ZRevRangeByScore(s.DB(), iconvert(args)...); err != nil {
+	if ay, err := s.Store().ZRevRangeByScore(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		resp := redis.NewArray()
@@ -226,7 +226,7 @@ func ZRankCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect 2", len(args))
 	}
 
-	if v, err := s.Store().ZRank(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZRank(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else if v >= 0 {
 		return redis.NewInt(v), nil
@@ -241,7 +241,7 @@ func ZRevRankCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect 2", len(args))
 	}
 
-	if v, err := s.Store().ZRevRank(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZRevRank(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else if v >= 0 {
 		return redis.NewInt(v), nil
@@ -256,7 +256,7 @@ func ZRemRangeByLexCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect 3", len(args))
 	}
 
-	if v, err := s.Store().ZRemRangeByLex(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZRemRangeByLex(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -269,7 +269,7 @@ func ZRemRangeByRankCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect 3", len(args))
 	}
 
-	if v, err := s.Store().ZRemRangeByRank(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZRemRangeByRank(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil
@@ -282,7 +282,7 @@ func ZRemRangeByScoreCmd(s Session, args [][]byte) (redis.Resp, error) {
 		return toRespErrorf("len(args) = %d, expect 3", len(args))
 	}
 
-	if v, err := s.Store().ZRemRangeByScore(s.DB(), iconvert(args)...); err != nil {
+	if v, err := s.Store().ZRemRangeByScore(s.DB(), args); err != nil {
 		return toRespError(err)
 	} else {
 		return redis.NewInt(v), nil

--- a/pkg/store/format.go
+++ b/pkg/store/format.go
@@ -216,3 +216,39 @@ func parseArgument(arg interface{}, ref interface{}) error {
 	}
 	return nil
 }
+
+func FormatByte(arg interface{}) []byte {
+	switch x := arg.(type) {
+	default:
+		return []byte{}
+	case int64:
+		return FormatInt(int64(x))
+	case int32:
+		return FormatInt(int64(x))
+	case int:
+		return FormatInt(int64(x))
+	case uint64:
+		return FormatUint(uint64(x))
+	case uint32:
+		return FormatUint(uint64(x))
+	case uint:
+		return FormatUint(uint64(x))
+	case float64:
+		return FormatFloat(float64(x))
+	case float32:
+		return FormatFloat(float64(x))
+	case []byte:
+		return x
+	case string:
+		return []byte(x)
+	}
+}
+
+func FormatBytes(args ...interface{}) [][]byte {
+	values := make([][]byte, len(args))
+	for i, arg := range args {
+		values[i] = FormatByte(arg)
+	}
+
+	return values
+}

--- a/pkg/store/forward.go
+++ b/pkg/store/forward.go
@@ -10,7 +10,7 @@ import (
 type Forward struct {
 	DB   uint32
 	Op   string
-	Args []interface{}
+	Args [][]byte
 }
 
 type ForwardHandler func(f *Forward) error

--- a/pkg/store/hash.go
+++ b/pkg/store/hash.go
@@ -47,7 +47,7 @@ func (o *hashRow) deleteObject(s *Store, bt *engine.Batch) error {
 	return it.Error()
 }
 
-func (o *hashRow) storeObject(s *Store, bt *engine.Batch, expireat uint64, obj interface{}) error {
+func (o *hashRow) storeObject(s *Store, bt *engine.Batch, expireat int64, obj interface{}) error {
 	hash, ok := obj.(rdb.Hash)
 	if !ok || len(hash) == 0 {
 		return errors.Trace(ErrObjectValue)
@@ -167,17 +167,12 @@ func (s *Store) loadHashRow(db uint32, key []byte, deleteIfExpired bool) (*hashR
 }
 
 // HGETALL key
-func (s *Store) HGetAll(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) HGetAll(db uint32, args [][]byte) ([][]byte, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -203,21 +198,13 @@ func (s *Store) HGetAll(db uint32, args ...interface{}) ([][]byte, error) {
 }
 
 // HDEL key field [field ...]
-func (s *Store) HDel(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) HDel(db uint32, args [][]byte) (int64, error) {
 	if len(args) < 2 {
 		return 0, errArguments("len(args) = %d, expect >= 2", len(args))
 	}
 
-	var key []byte
-	var fields = make([][]byte, len(args)-1)
-	if err := parseArgument(args[0], &key); err != nil {
-		return 0, errArguments("parse args[%d] failed, %s", 0, err)
-	}
-	for i := 0; i < len(fields); i++ {
-		if err := parseArgument(args[i+1], &fields[i]); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i+1, err)
-		}
-	}
+	key := args[0]
+	fields := args[1:]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -257,17 +244,13 @@ func (s *Store) HDel(db uint32, args ...interface{}) (int64, error) {
 }
 
 // HEXISTS key field
-func (s *Store) HExists(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) HExists(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, field []byte
-	for i, ref := range []interface{}{&key, &field} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	field := args[1]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -289,17 +272,13 @@ func (s *Store) HExists(db uint32, args ...interface{}) (int64, error) {
 }
 
 // HGET key field
-func (s *Store) HGet(db uint32, args ...interface{}) ([]byte, error) {
+func (s *Store) HGet(db uint32, args [][]byte) ([]byte, error) {
 	if len(args) != 2 {
 		return nil, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, field []byte
-	for i, ref := range []interface{}{&key, &field} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	field := args[1]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -321,17 +300,12 @@ func (s *Store) HGet(db uint32, args ...interface{}) ([]byte, error) {
 }
 
 // HLEN key
-func (s *Store) HLen(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) HLen(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -346,17 +320,16 @@ func (s *Store) HLen(db uint32, args ...interface{}) (int64, error) {
 }
 
 // HINCRBY key field delta
-func (s *Store) HIncrBy(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) HIncrBy(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, field []byte
-	var delta int64
-	for i, ref := range []interface{}{&key, &field, &delta} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	field := args[1]
+	delta, err := ParseInt(args[2])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -399,17 +372,16 @@ func (s *Store) HIncrBy(db uint32, args ...interface{}) (int64, error) {
 }
 
 // HINCRBYFLOAT key field delta
-func (s *Store) HIncrByFloat(db uint32, args ...interface{}) (float64, error) {
+func (s *Store) HIncrByFloat(db uint32, args [][]byte) (float64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, field []byte
-	var delta float64
-	for i, ref := range []interface{}{&key, &field, &delta} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	field := args[1]
+	delta, err := ParseFloat(args[2])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -457,17 +429,12 @@ func (s *Store) HIncrByFloat(db uint32, args ...interface{}) (float64, error) {
 }
 
 // HKEYS key
-func (s *Store) HKeys(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) HKeys(db uint32, args [][]byte) ([][]byte, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -482,17 +449,12 @@ func (s *Store) HKeys(db uint32, args ...interface{}) ([][]byte, error) {
 }
 
 // HVALS key
-func (s *Store) HVals(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) HVals(db uint32, args [][]byte) ([][]byte, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -507,17 +469,14 @@ func (s *Store) HVals(db uint32, args ...interface{}) ([][]byte, error) {
 }
 
 // HSET key field value
-func (s *Store) HSet(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) HSet(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, field, value []byte
-	for i, ref := range []interface{}{&key, &field, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	field := args[1]
+	value := args[2]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -558,17 +517,14 @@ func (s *Store) HSet(db uint32, args ...interface{}) (int64, error) {
 }
 
 // HSETNX key field value
-func (s *Store) HSetNX(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) HSetNX(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, field, value []byte
-	for i, ref := range []interface{}{&key, &field, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	field := args[1]
+	value := args[2]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -605,24 +561,18 @@ func (s *Store) HSetNX(db uint32, args ...interface{}) (int64, error) {
 }
 
 // HMSET key field value [field value ...]
-func (s *Store) HMSet(db uint32, args ...interface{}) error {
+func (s *Store) HMSet(db uint32, args [][]byte) error {
 	if len(args) == 1 || len(args)%2 != 1 {
 		return errArguments("len(args) = %d, expect != 1 && mod 2 = 1", len(args))
 	}
 
-	var key []byte
+	key := args[0]
+
 	var eles = make([]*rdb.HashElement, len(args)/2)
-	if err := parseArgument(args[0], &key); err != nil {
-		return errArguments("parse args[%d] failed, %s", 0, err)
-	}
 	for i := 0; i < len(eles); i++ {
 		e := &rdb.HashElement{}
-		if err := parseArgument(args[i*2+1], &e.Field); err != nil {
-			return errArguments("parse args[%d] failed, %s", i*2+1, err)
-		}
-		if err := parseArgument(args[i*2+2], &e.Value); err != nil {
-			return errArguments("parse args[%d] failed, %s", i*2+2, err)
-		}
+		e.Field = args[i*2+1]
+		e.Value = args[i*2+2]
 		eles[i] = e
 	}
 
@@ -664,21 +614,14 @@ func (s *Store) HMSet(db uint32, args ...interface{}) error {
 }
 
 // HMGET key field [field ...]
-func (s *Store) HMGet(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) HMGet(db uint32, args [][]byte) ([][]byte, error) {
 	if len(args) < 2 {
 		return nil, errArguments("len(args) = %d, expect >= 2", len(args))
 	}
 
-	var key []byte
-	var fields = make([][]byte, len(args)-1)
-	if err := parseArgument(args[0], &key); err != nil {
-		return nil, errArguments("parse args[%d] failed, %s", 0, err)
-	}
-	for i := 0; i < len(fields); i++ {
-		if err := parseArgument(args[i+1], &fields[i]); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i+1, err)
-		}
-	}
+	key := args[0]
+	fields := args[0:]
+
 	var values = make([][]byte, len(fields))
 
 	if err := s.acquire(); err != nil {

--- a/pkg/store/hash.go
+++ b/pkg/store/hash.go
@@ -620,7 +620,7 @@ func (s *Store) HMGet(db uint32, args [][]byte) ([][]byte, error) {
 	}
 
 	key := args[0]
-	fields := args[0:]
+	fields := args[1:]
 
 	var values = make([][]byte, len(fields))
 

--- a/pkg/store/hash_test.go
+++ b/pkg/store/hash_test.go
@@ -19,7 +19,7 @@ func (s *testStoreSuite) hdelall(c *C, db uint32, key string, expect int64) {
 func (s *testStoreSuite) hdump(c *C, db uint32, key string, expect ...string) {
 	s.kexists(c, db, key, 1)
 
-	v, err := s.s.Dump(db, key)
+	v, err := s.s.Dump(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(v, NotNil)
 
@@ -53,7 +53,7 @@ func (s *testStoreSuite) hrestore(c *C, db uint32, key string, ttlms int64, expe
 	dump, err := rdb.EncodeDump(x)
 	c.Assert(err, IsNil)
 
-	err = s.s.Restore(db, key, ttlms, dump)
+	err = s.s.Restore(db, FormatBytes(key, ttlms, dump))
 	c.Assert(err, IsNil)
 
 	s.hdump(c, db, key, expect...)
@@ -65,7 +65,7 @@ func (s *testStoreSuite) hrestore(c *C, db uint32, key string, ttlms int64, expe
 }
 
 func (s *testStoreSuite) hlen(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.HLen(db, key)
+	x, err := s.s.HLen(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -82,7 +82,7 @@ func (s *testStoreSuite) hdel(c *C, db uint32, key string, expect int64, fields 
 		args = append(args, f)
 	}
 
-	x, err := s.s.HDel(db, args...)
+	x, err := s.s.HDel(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -92,13 +92,13 @@ func (s *testStoreSuite) hdel(c *C, db uint32, key string, expect int64, fields 
 }
 
 func (s *testStoreSuite) hexists(c *C, db uint32, key, field string, expect int64) {
-	x, err := s.s.HExists(db, key, field)
+	x, err := s.s.HExists(db, FormatBytes(key, field))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) hgetall(c *C, db uint32, key string, expect ...string) {
-	x, err := s.s.HGetAll(db, key)
+	x, err := s.s.HGetAll(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 
 	if len(expect) == 0 {
@@ -128,7 +128,7 @@ func (s *testStoreSuite) hgetall(c *C, db uint32, key string, expect ...string) 
 }
 
 func (s *testStoreSuite) hget(c *C, db uint32, key, field string, expect string) {
-	x, err := s.s.HGet(db, key, field)
+	x, err := s.s.HGet(db, FormatBytes(key, field))
 	c.Assert(err, IsNil)
 
 	if expect == "" {
@@ -141,7 +141,7 @@ func (s *testStoreSuite) hget(c *C, db uint32, key, field string, expect string)
 }
 
 func (s *testStoreSuite) hkeys(c *C, db uint32, key string, expect ...string) {
-	x, err := s.s.HKeys(db, key)
+	x, err := s.s.HKeys(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(len(x), Equals, len(expect))
 
@@ -166,7 +166,7 @@ func (s *testStoreSuite) hkeys(c *C, db uint32, key string, expect ...string) {
 }
 
 func (s *testStoreSuite) hvals(c *C, db uint32, key string, expect ...string) {
-	x, err := s.s.HVals(db, key)
+	x, err := s.s.HVals(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(len(x), Equals, len(expect))
 
@@ -192,19 +192,19 @@ func (s *testStoreSuite) hvals(c *C, db uint32, key string, expect ...string) {
 }
 
 func (s *testStoreSuite) hincrby(c *C, db uint32, key, field string, delta int64, expect int64) {
-	x, err := s.s.HIncrBy(db, key, field, delta)
+	x, err := s.s.HIncrBy(db, FormatBytes(key, field, delta))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) hincrbyfloat(c *C, db uint32, key, field string, delta float64, expect float64) {
-	x, err := s.s.HIncrByFloat(db, key, field, delta)
+	x, err := s.s.HIncrByFloat(db, FormatBytes(key, field, delta))
 	c.Assert(err, IsNil)
 	c.Assert(math.Abs(x-expect) < 1e-9, Equals, true)
 }
 
 func (s *testStoreSuite) hset(c *C, db uint32, key, field, value string, expect int64) {
-	x, err := s.s.HSet(db, key, field, value)
+	x, err := s.s.HSet(db, FormatBytes(key, field, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -212,7 +212,7 @@ func (s *testStoreSuite) hset(c *C, db uint32, key, field, value string, expect 
 }
 
 func (s *testStoreSuite) hsetnx(c *C, db uint32, key, field, value string, expect int64) {
-	x, err := s.s.HSetNX(db, key, field, value)
+	x, err := s.s.HSetNX(db, FormatBytes(key, field, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -230,7 +230,7 @@ func (s *testStoreSuite) hmset(c *C, db uint32, key string, pairs ...string) {
 		args = append(args, pairs[i])
 	}
 
-	err := s.s.HMSet(db, args...)
+	err := s.s.HMSet(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 
 	for i := 0; i < len(pairs); i += 2 {
@@ -246,7 +246,7 @@ func (s *testStoreSuite) hmget(c *C, db uint32, key string, pairs ...string) {
 		args = append(args, pairs[i])
 	}
 
-	x, err := s.s.HMGet(db, args...)
+	x, err := s.s.HMGet(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(len(x), Equals, len(pairs)/2)
 
@@ -355,10 +355,10 @@ func (s *testStoreSuite) TestHIncrFloat(c *C) {
 	s.hincrbyfloat(c, 0, "hash", "a", 3.14, 303.14)
 	s.hincrbyfloat(c, 0, "hash", "a", -303.14, 0)
 
-	_, err := s.s.HIncrByFloat(0, "hash", "a", math.Inf(1))
+	_, err := s.s.HIncrByFloat(0, FormatBytes("hash", "a", math.Inf(1)))
 	c.Assert(err, NotNil)
 
-	_, err = s.s.HIncrByFloat(0, "hash", "a", math.Inf(-1))
+	_, err = s.s.HIncrByFloat(0, FormatBytes("hash", "a", math.Inf(-1)))
 	c.Assert(err, NotNil)
 
 	s.hdelall(c, 0, "hash", 1)

--- a/pkg/store/keys.go
+++ b/pkg/store/keys.go
@@ -26,7 +26,7 @@ func (s *Store) loadStoreRow(db uint32, key []byte, deleteIfExpired bool) (store
 		if err := o.deleteObject(s, bt); err != nil {
 			return nil, err
 		}
-		fw := &Forward{DB: db, Op: "Del", Args: []interface{}{key}}
+		fw := &Forward{DB: db, Op: "Del", Args: [][]byte{key}}
 		return nil, s.commit(bt, fw)
 	}
 	return o, nil
@@ -41,17 +41,12 @@ func (s *Store) deleteIfExists(bt *engine.Batch, db uint32, key []byte) (bool, e
 }
 
 // DEL key [key ...]
-func (s *Store) Del(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Del(db uint32, args [][]byte) (int64, error) {
 	if len(args) == 0 {
 		return 0, errArguments("len(args) = %d, expect != 0", len(args))
 	}
 
-	keys := make([][]byte, len(args))
-	for i := 0; i < len(keys); i++ {
-		if err := parseArgument(args[i], &keys[i]); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", err)
-		}
-	}
+	keys := args
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -83,17 +78,12 @@ func (s *Store) Del(db uint32, args ...interface{}) (int64, error) {
 }
 
 // DUMP key
-func (s *Store) Dump(db uint32, args ...interface{}) (interface{}, error) {
+func (s *Store) Dump(db uint32, args [][]byte) (interface{}, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -113,17 +103,12 @@ func (s *Store) Dump(db uint32, args ...interface{}) (interface{}, error) {
 }
 
 // TYPE key
-func (s *Store) Type(db uint32, args ...interface{}) (ObjectCode, error) {
+func (s *Store) Type(db uint32, args [][]byte) (ObjectCode, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -138,17 +123,12 @@ func (s *Store) Type(db uint32, args ...interface{}) (ObjectCode, error) {
 }
 
 // EXISTS key
-func (s *Store) Exists(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Exists(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -164,17 +144,12 @@ func (s *Store) Exists(db uint32, args ...interface{}) (int64, error) {
 }
 
 // TTL key
-func (s *Store) TTL(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) TTL(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -189,17 +164,12 @@ func (s *Store) TTL(db uint32, args ...interface{}) (int64, error) {
 }
 
 // PTTL key
-func (s *Store) PTTL(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) PTTL(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -222,7 +192,7 @@ func (s *Store) getExpireTTLms(db uint32, key []byte) (int64, error) {
 	}
 }
 
-func (s *Store) setExpireAt(db uint32, key []byte, expireat uint64) (int64, error) {
+func (s *Store) setExpireAt(db uint32, key []byte, expireat int64) (int64, error) {
 	o, err := s.loadStoreRow(db, key, true)
 	if err != nil || o == nil {
 		return 0, err
@@ -231,30 +201,25 @@ func (s *Store) setExpireAt(db uint32, key []byte, expireat uint64) (int64, erro
 	if !IsExpired(expireat) {
 		o.SetExpireAt(expireat)
 		bt.Set(o.MetaKey(), o.MetaValue())
-		fw := &Forward{DB: db, Op: "PExpireAt", Args: []interface{}{key, expireat}}
+		fw := &Forward{DB: db, Op: "PExpireAt", Args: [][]byte{key, FormatInt(expireat)}}
 		return 1, s.commit(bt, fw)
 	} else {
 		_, err := s.deleteIfExists(bt, db, key)
 		if err != nil {
 			return 0, err
 		}
-		fw := &Forward{DB: db, Op: "Del", Args: []interface{}{key}}
+		fw := &Forward{DB: db, Op: "Del", Args: [][]byte{key}}
 		return 1, s.commit(bt, fw)
 	}
 }
 
 // PERSIST key
-func (s *Store) Persist(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Persist(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -277,20 +242,18 @@ func (s *Store) Persist(db uint32, args ...interface{}) (int64, error) {
 }
 
 // EXPIRE key seconds
-func (s *Store) Expire(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Expire(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var ttls int64
-	for i, ref := range []interface{}{&key, &ttls} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	ttls, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
-	expireat := uint64(0)
+	expireat := int64(0)
 	if v, ok := TTLsToExpireAt(ttls); ok && v > 0 {
 		expireat = v
 	} else {
@@ -306,20 +269,18 @@ func (s *Store) Expire(db uint32, args ...interface{}) (int64, error) {
 }
 
 // PEXPIRE key milliseconds
-func (s *Store) PExpire(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) PExpire(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var ttlms int64
-	for i, ref := range []interface{}{&key, &ttlms} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	ttlms, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
-	expireat := uint64(0)
+	expireat := int64(0)
 	if v, ok := TTLmsToExpireAt(ttlms); ok && v > 0 {
 		expireat = v
 	} else {
@@ -335,23 +296,22 @@ func (s *Store) PExpire(db uint32, args ...interface{}) (int64, error) {
 }
 
 // EXPIREAT key timestamp
-func (s *Store) ExpireAt(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ExpireAt(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var timestamp uint64
-	for i, ref := range []interface{}{&key, &timestamp} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	timestamp, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+
 	if timestamp > MaxExpireAt/1e3 {
 		return 0, errArguments("parse timestamp = %d", timestamp)
 	}
 
-	expireat := uint64(1)
+	expireat := int64(1)
 	if timestamp != 0 {
 		expireat = timestamp * 1e3
 	}
@@ -365,23 +325,22 @@ func (s *Store) ExpireAt(db uint32, args ...interface{}) (int64, error) {
 }
 
 // PEXPIREAT key milliseconds-timestamp
-func (s *Store) PExpireAt(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) PExpireAt(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var mtimestamp uint64
-	for i, ref := range []interface{}{&key, &mtimestamp} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	mtimestamp, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+
 	if mtimestamp > MaxExpireAt {
 		return 0, errArguments("parse mtimestamp = %d", mtimestamp)
 	}
 
-	expireat := uint64(1)
+	expireat := int64(1)
 	if mtimestamp != 0 {
 		expireat = mtimestamp
 	}
@@ -395,20 +354,19 @@ func (s *Store) PExpireAt(db uint32, args ...interface{}) (int64, error) {
 }
 
 // RESTORE key ttlms value
-func (s *Store) Restore(db uint32, args ...interface{}) error {
+func (s *Store) Restore(db uint32, args [][]byte) error {
 	if len(args) != 3 {
 		return errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key, value []byte
-	var ttlms int64
-	for i, ref := range []interface{}{&key, &ttlms, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	value := args[1]
+	ttlms, err := ParseInt(args[2])
+	if err != nil {
+		return errArguments("parse args failed - %s", err)
 	}
 
-	expireat := uint64(0)
+	expireat := int64(0)
 	if ttlms != 0 {
 		if v, ok := TTLmsToExpireAt(ttlms); ok && v > 0 {
 			expireat = v
@@ -435,7 +393,7 @@ func (s *Store) Restore(db uint32, args ...interface{}) error {
 	return s.commit(bt, fw)
 }
 
-func (s *Store) restore(bt *engine.Batch, db uint32, key []byte, expireat uint64, obj interface{}) error {
+func (s *Store) restore(bt *engine.Batch, db uint32, key []byte, expireat int64, obj interface{}) error {
 	_, err := s.deleteIfExists(bt, db, key)
 	if err != nil {
 		return err
@@ -489,11 +447,11 @@ func (s *Store) Info() (string, error) {
 	return s.db.Stats(), nil
 }
 
-func nowms() uint64 {
-	return uint64(time.Now().UnixNano()) / uint64(time.Millisecond)
+func nowms() int64 {
+	return int64(time.Now().UnixNano()) / int64(time.Millisecond)
 }
 
-func ExpireAtToTTLms(expireat uint64) (int64, bool) {
+func ExpireAtToTTLms(expireat int64) (int64, bool) {
 	switch {
 	case expireat > MaxExpireAt:
 		return -1, false
@@ -508,18 +466,18 @@ func ExpireAtToTTLms(expireat uint64) (int64, bool) {
 	}
 }
 
-func TTLsToExpireAt(ttls int64) (uint64, bool) {
+func TTLsToExpireAt(ttls int64) (int64, bool) {
 	if ttls < 0 || ttls > MaxExpireAt/1e3 {
 		return 0, false
 	}
 	return TTLmsToExpireAt(ttls * 1e3)
 }
 
-func TTLmsToExpireAt(ttlms int64) (uint64, bool) {
+func TTLmsToExpireAt(ttlms int64) (int64, bool) {
 	if ttlms < 0 || ttlms > MaxExpireAt {
 		return 0, false
 	}
-	expireat := nowms() + uint64(ttlms)
+	expireat := nowms() + ttlms
 	if expireat > MaxExpireAt {
 		return 0, false
 	}

--- a/pkg/store/keys.go
+++ b/pkg/store/keys.go
@@ -360,11 +360,11 @@ func (s *Store) Restore(db uint32, args [][]byte) error {
 	}
 
 	key := args[0]
-	value := args[1]
-	ttlms, err := ParseInt(args[2])
+	ttlms, err := ParseInt(args[1])
 	if err != nil {
 		return errArguments("parse args failed - %s", err)
 	}
+	value := args[2]
 
 	expireat := int64(0)
 	if ttlms != 0 {

--- a/pkg/store/keys_test.go
+++ b/pkg/store/keys_test.go
@@ -15,7 +15,7 @@ func (s *testStoreSuite) kdel(c *C, db uint32, expect int64, keys ...string) {
 		args[i] = key
 	}
 
-	n, err := s.s.Del(db, args...)
+	n, err := s.s.Del(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, expect)
 
@@ -25,7 +25,7 @@ func (s *testStoreSuite) kdel(c *C, db uint32, expect int64, keys ...string) {
 }
 
 func (s *testStoreSuite) ktype(c *C, db uint32, key string, expect ObjectCode) {
-	x, err := s.s.Type(db, key)
+	x, err := s.s.Type(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -37,13 +37,13 @@ func (s *testStoreSuite) ktype(c *C, db uint32, key string, expect ObjectCode) {
 }
 
 func (s *testStoreSuite) kexists(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.Exists(db, key)
+	x, err := s.s.Exists(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) kttl(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.TTL(db, key)
+	x, err := s.s.TTL(db, FormatBytes(key))
 	switch expect {
 	case -1, -2, 0:
 		c.Assert(err, IsNil)
@@ -55,7 +55,7 @@ func (s *testStoreSuite) kttl(c *C, db uint32, key string, expect int64) {
 }
 
 func (s *testStoreSuite) kpttl(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.PTTL(db, key)
+	x, err := s.s.PTTL(db, FormatBytes(key))
 	switch expect {
 	case -1, -2, 0:
 		c.Assert(err, IsNil)
@@ -67,7 +67,7 @@ func (s *testStoreSuite) kpttl(c *C, db uint32, key string, expect int64) {
 }
 
 func (s *testStoreSuite) kpersist(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.Persist(db, key)
+	x, err := s.s.Persist(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -77,7 +77,7 @@ func (s *testStoreSuite) kpersist(c *C, db uint32, key string, expect int64) {
 }
 
 func (s *testStoreSuite) kexpire(c *C, db uint32, key string, ttls uint64, expect int64) {
-	x, err := s.s.Expire(db, key, ttls)
+	x, err := s.s.Expire(db, FormatBytes(key, ttls))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -91,7 +91,7 @@ func (s *testStoreSuite) kexpire(c *C, db uint32, key string, ttls uint64, expec
 }
 
 func (s *testStoreSuite) kpexpire(c *C, db uint32, key string, ttlms uint64, expect int64) {
-	x, err := s.s.PExpire(db, key, ttlms)
+	x, err := s.s.PExpire(db, FormatBytes(key, ttlms))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -104,8 +104,8 @@ func (s *testStoreSuite) kpexpire(c *C, db uint32, key string, ttlms uint64, exp
 	}
 }
 
-func (s *testStoreSuite) kexpireat(c *C, db uint32, key string, timestamp uint64, expect int64) {
-	x, err := s.s.ExpireAt(db, key, timestamp)
+func (s *testStoreSuite) kexpireat(c *C, db uint32, key string, timestamp int64, expect int64) {
+	x, err := s.s.ExpireAt(db, FormatBytes(key, timestamp))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -119,8 +119,8 @@ func (s *testStoreSuite) kexpireat(c *C, db uint32, key string, timestamp uint64
 	}
 }
 
-func (s *testStoreSuite) kpexpireat(c *C, db uint32, key string, expireat uint64, expect int64) {
-	x, err := s.s.PExpireAt(db, key, expireat)
+func (s *testStoreSuite) kpexpireat(c *C, db uint32, key string, expireat int64, expect int64) {
+	x, err := s.s.PExpireAt(db, FormatBytes(key, expireat))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 

--- a/pkg/store/list.go
+++ b/pkg/store/list.go
@@ -199,11 +199,11 @@ func (s *Store) LSet(db uint32, args [][]byte) error {
 	}
 
 	key := args[0]
-	value := args[1]
-	index, err := ParseInt(args[2])
+	index, err := ParseInt(args[1])
 	if err != nil {
 		return errArguments("parse args failed - %s", err)
 	}
+	value := args[2]
 
 	if err := s.acquire(); err != nil {
 		return err

--- a/pkg/store/list.go
+++ b/pkg/store/list.go
@@ -52,7 +52,7 @@ func (o *listRow) deleteObject(s *Store, bt *engine.Batch) error {
 	return it.Error()
 }
 
-func (o *listRow) storeObject(s *Store, bt *engine.Batch, expireat uint64, obj interface{}) error {
+func (o *listRow) storeObject(s *Store, bt *engine.Batch, expireat int64, obj interface{}) error {
 	list, ok := obj.(rdb.List)
 	if !ok || len(list) == 0 {
 		return errors.Trace(ErrObjectValue)
@@ -101,17 +101,15 @@ func (s *Store) loadListRow(db uint32, key []byte, deleteIfExpired bool) (*listR
 }
 
 // LINDEX key index
-func (s *Store) LIndex(db uint32, args ...interface{}) ([]byte, error) {
+func (s *Store) LIndex(db uint32, args [][]byte) ([]byte, error) {
 	if len(args) != 2 {
 		return nil, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var index int64
-	for i, ref := range []interface{}{&key, &index} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	index, err := ParseInt(args[1])
+	if err != nil {
+		return nil, errArguments("parse args failed - %s", err)
 	}
 
 	o, err := s.loadListRow(db, key, true)
@@ -132,17 +130,12 @@ func (s *Store) LIndex(db uint32, args ...interface{}) ([]byte, error) {
 }
 
 // LLEN key
-func (s *Store) LLen(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) LLen(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -157,17 +150,19 @@ func (s *Store) LLen(db uint32, args ...interface{}) (int64, error) {
 }
 
 // LRANGE key beg end
-func (s *Store) LRange(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) LRange(db uint32, args [][]byte) ([][]byte, error) {
 	if len(args) != 3 {
 		return nil, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var beg, end int64
-	for i, ref := range []interface{}{&key, &beg, &end} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	beg, err := ParseInt(args[1])
+	if err != nil {
+		return nil, errArguments("parse args failed - %s", err)
+	}
+	end, err := ParseInt(args[2])
+	if err != nil {
+		return nil, errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -198,17 +193,16 @@ func (s *Store) LRange(db uint32, args ...interface{}) ([][]byte, error) {
 }
 
 // LSET key index value
-func (s *Store) LSet(db uint32, args ...interface{}) error {
+func (s *Store) LSet(db uint32, args [][]byte) error {
 	if len(args) != 3 {
 		return errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, value []byte
-	var index int64
-	for i, ref := range []interface{}{&key, &index, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	value := args[1]
+	index, err := ParseInt(args[2])
+	if err != nil {
+		return errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -238,17 +232,19 @@ func (s *Store) LSet(db uint32, args ...interface{}) error {
 }
 
 // LTRIM key beg end
-func (s *Store) LTrim(db uint32, args ...interface{}) error {
+func (s *Store) LTrim(db uint32, args [][]byte) error {
 	if len(args) != 3 {
 		return errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var beg, end int64
-	for i, ref := range []interface{}{&key, &beg, &end} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	beg, err := ParseInt(args[1])
+	if err != nil {
+		return errArguments("parse args failed - %s", err)
+	}
+	end, err := ParseInt(args[2])
+	if err != nil {
+		return errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -288,17 +284,12 @@ func (s *Store) LTrim(db uint32, args ...interface{}) error {
 }
 
 // LPOP key
-func (s *Store) LPop(db uint32, args ...interface{}) ([]byte, error) {
+func (s *Store) LPop(db uint32, args [][]byte) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -327,17 +318,12 @@ func (s *Store) LPop(db uint32, args ...interface{}) ([]byte, error) {
 }
 
 // RPOP key
-func (s *Store) RPop(db uint32, args ...interface{}) ([]byte, error) {
+func (s *Store) RPop(db uint32, args [][]byte) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -366,21 +352,13 @@ func (s *Store) RPop(db uint32, args ...interface{}) ([]byte, error) {
 }
 
 // LPUSH key value [value ...]
-func (s *Store) LPush(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) LPush(db uint32, args [][]byte) (int64, error) {
 	if len(args) < 2 {
 		return 0, errArguments("len(args) = %d, expect >= 2", len(args))
 	}
 
-	var key []byte
-	var values = make([][]byte, len(args)-1)
-	if err := parseArgument(args[0], &key); err != nil {
-		return 0, errArguments("parse args[%d] failed, %s", 0, err)
-	}
-	for i := 0; i < len(values); i++ {
-		if err := parseArgument(args[i+1], &values[i]); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i+1, err)
-		}
-	}
+	key := args[0]
+	values := args[1:]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -391,17 +369,13 @@ func (s *Store) LPush(db uint32, args ...interface{}) (int64, error) {
 }
 
 // LPUSHX key value
-func (s *Store) LPushX(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) LPushX(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, value []byte
-	for i, ref := range []interface{}{&key, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	value := args[1]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -412,21 +386,13 @@ func (s *Store) LPushX(db uint32, args ...interface{}) (int64, error) {
 }
 
 // RPUSH key value [value ...]
-func (s *Store) RPush(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) RPush(db uint32, args [][]byte) (int64, error) {
 	if len(args) < 2 {
 		return 0, errArguments("len(args) = %d, expect >= 2", len(args))
 	}
 
-	var key []byte
-	var values = make([][]byte, len(args)-1)
-	if err := parseArgument(args[0], &key); err != nil {
-		return 0, errArguments("parse args[%d] failed, %s", 0, err)
-	}
-	for i := 0; i < len(values); i++ {
-		if err := parseArgument(args[i+1], &values[i]); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i+1, err)
-		}
-	}
+	key := args[0]
+	values := args[1:]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -437,17 +403,13 @@ func (s *Store) RPush(db uint32, args ...interface{}) (int64, error) {
 }
 
 // RPUSHX key value
-func (s *Store) RPushX(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) RPushX(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, value []byte
-	for i, ref := range []interface{}{&key, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	value := args[1]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -470,7 +432,7 @@ func (s *Store) lpush(db uint32, key []byte, create bool, values ...[]byte) (int
 		o = newListRow(db, key)
 	}
 
-	fw := &Forward{DB: db, Op: "LPush", Args: []interface{}{key}}
+	fw := &Forward{DB: db, Op: "LPush", Args: [][]byte{key}}
 	bt := engine.NewBatch()
 	for _, value := range values {
 		o.Lindex--
@@ -495,7 +457,7 @@ func (s *Store) rpush(db uint32, key []byte, create bool, values ...[]byte) (int
 		o = newListRow(db, key)
 	}
 
-	fw := &Forward{DB: db, Op: "RPush", Args: []interface{}{key}}
+	fw := &Forward{DB: db, Op: "RPush", Args: [][]byte{key}}
 	bt := engine.NewBatch()
 	for _, value := range values {
 		o.Index, o.Value = o.Rindex, value

--- a/pkg/store/list_test.go
+++ b/pkg/store/list_test.go
@@ -18,7 +18,7 @@ func (s *testStoreSuite) ldel(c *C, db uint32, key string, expect int64) {
 func (s *testStoreSuite) ldump(c *C, db uint32, key string, expect ...string) {
 	s.kexists(c, db, key, 1)
 
-	v, err := s.s.Dump(db, key)
+	v, err := s.s.Dump(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(v, NotNil)
 
@@ -36,7 +36,7 @@ func (s *testStoreSuite) ldump(c *C, db uint32, key string, expect ...string) {
 }
 
 func (s *testStoreSuite) llen(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.LLen(db, key)
+	x, err := s.s.LLen(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -48,7 +48,7 @@ func (s *testStoreSuite) llen(c *C, db uint32, key string, expect int64) {
 }
 
 func (s *testStoreSuite) lindex(c *C, db uint32, key string, index int, expect string) {
-	x, err := s.s.LIndex(db, key, index)
+	x, err := s.s.LIndex(db, FormatBytes(key, index))
 	c.Assert(err, IsNil)
 
 	if expect == "" {
@@ -59,7 +59,7 @@ func (s *testStoreSuite) lindex(c *C, db uint32, key string, index int, expect s
 }
 
 func (s *testStoreSuite) lrange(c *C, db uint32, key string, beg, end int, expect ...string) {
-	x, err := s.s.LRange(db, key, beg, end)
+	x, err := s.s.LRange(db, FormatBytes(key, beg, end))
 	c.Assert(err, IsNil)
 	c.Assert(len(x), Equals, len(expect))
 
@@ -69,7 +69,7 @@ func (s *testStoreSuite) lrange(c *C, db uint32, key string, beg, end int, expec
 }
 
 func (s *testStoreSuite) lset(c *C, db uint32, key string, index int, value string) {
-	err := s.s.LSet(db, key, index, value)
+	err := s.s.LSet(db, FormatBytes(key, index, value))
 	c.Assert(err, IsNil)
 
 	s.lrange(c, db, key, index, index, value)
@@ -77,12 +77,12 @@ func (s *testStoreSuite) lset(c *C, db uint32, key string, index int, value stri
 }
 
 func (s *testStoreSuite) ltrim(c *C, db uint32, key string, beg, end int) {
-	err := s.s.LTrim(db, key, beg, end)
+	err := s.s.LTrim(db, FormatBytes(key, beg, end))
 	c.Assert(err, IsNil)
 }
 
 func (s *testStoreSuite) lpop(c *C, db uint32, key string, expect string) {
-	x, err := s.s.LPop(db, key)
+	x, err := s.s.LPop(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 
 	if expect == "" {
@@ -93,7 +93,7 @@ func (s *testStoreSuite) lpop(c *C, db uint32, key string, expect string) {
 }
 
 func (s *testStoreSuite) rpop(c *C, db uint32, key string, expect string) {
-	x, err := s.s.RPop(db, key)
+	x, err := s.s.RPop(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 
 	if expect == "" {
@@ -109,7 +109,7 @@ func (s *testStoreSuite) lpush(c *C, db uint32, key string, expect int64, values
 		args = append(args, v)
 	}
 
-	x, err := s.s.LPush(db, args...)
+	x, err := s.s.LPush(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -122,7 +122,7 @@ func (s *testStoreSuite) rpush(c *C, db uint32, key string, expect int64, values
 		args = append(args, v)
 	}
 
-	x, err := s.s.RPush(db, args...)
+	x, err := s.s.RPush(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -130,7 +130,7 @@ func (s *testStoreSuite) rpush(c *C, db uint32, key string, expect int64, values
 }
 
 func (s *testStoreSuite) lpushx(c *C, db uint32, key string, value string, expect int64) {
-	x, err := s.s.LPushX(db, key, value)
+	x, err := s.s.LPushX(db, FormatBytes(key, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -138,7 +138,7 @@ func (s *testStoreSuite) lpushx(c *C, db uint32, key string, value string, expec
 }
 
 func (s *testStoreSuite) rpushx(c *C, db uint32, key string, value string, expect int64) {
-	x, err := s.s.RPushX(db, key, value)
+	x, err := s.s.RPushX(db, FormatBytes(key, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -154,7 +154,7 @@ func (s *testStoreSuite) lrestore(c *C, db uint32, key string, ttlms int64, expe
 	dump, err := rdb.EncodeDump(x)
 	c.Assert(err, IsNil)
 
-	err = s.s.Restore(db, key, ttlms, dump)
+	err = s.s.Restore(db, FormatBytes(key, ttlms, dump))
 	c.Assert(err, IsNil)
 
 	s.ldump(c, db, key, expect...)

--- a/pkg/store/migrate.go
+++ b/pkg/store/migrate.go
@@ -182,7 +182,7 @@ func doMigrate(addr string, timeout time.Duration, db uint32, bins []*rdb.BinEnt
 		cmd2.AppendBulkBytes(bin.Key)
 		ttlms := int64(0)
 		if bin.ExpireAt != 0 {
-			if v, ok := ExpireAtToTTLms(bin.ExpireAt); ok && v > 0 {
+			if v, ok := ExpireAtToTTLms(int64(bin.ExpireAt)); ok && v > 0 {
 				ttlms = v
 			} else {
 				ttlms = 1

--- a/pkg/store/reader.go
+++ b/pkg/store/reader.go
@@ -36,7 +36,7 @@ func loadObjEntry(r storeReader, db uint32, key []byte) (storeRow, *rdb.ObjEntry
 			DB:       db,
 			Key:      key,
 			Value:    val,
-			ExpireAt: o.GetExpireAt(),
+			ExpireAt: uint64(o.GetExpireAt()),
 		}
 		return o, obj, nil
 	}

--- a/pkg/store/row.go
+++ b/pkg/store/row.go
@@ -94,12 +94,12 @@ type storeRow interface {
 	LoadDataValue(r storeReader) (bool, error)
 	TestDataValue(r storeReader) (bool, error)
 
-	GetExpireAt() uint64
-	SetExpireAt(expireat uint64)
+	GetExpireAt() int64
+	SetExpireAt(expireat int64)
 	IsExpired() bool
 
 	lazyInit(db uint32, key []byte, h *storeRowHelper)
-	storeObject(s *Store, bt *engine.Batch, expireat uint64, obj interface{}) error
+	storeObject(s *Store, bt *engine.Batch, expireat int64, obj interface{}) error
 	deleteObject(s *Store, bt *engine.Batch) error
 	loadObjectValue(r storeReader) (interface{}, error)
 }
@@ -109,7 +109,7 @@ type storeRowHelper struct {
 	metaKey       []byte
 	dataKeyPrefix []byte
 
-	ExpireAt uint64
+	ExpireAt int64
 
 	dataKeyRefs   []interface{}
 	metaValueRefs []interface{}
@@ -232,11 +232,11 @@ func (o *storeRowHelper) TestDataValue(r storeReader) (bool, error) {
 	return true, nil
 }
 
-func (o *storeRowHelper) GetExpireAt() uint64 {
+func (o *storeRowHelper) GetExpireAt() int64 {
 	return o.ExpireAt
 }
 
-func (o *storeRowHelper) SetExpireAt(expireat uint64) {
+func (o *storeRowHelper) SetExpireAt(expireat int64) {
 	o.ExpireAt = expireat
 }
 
@@ -244,7 +244,7 @@ func (o *storeRowHelper) IsExpired() bool {
 	return IsExpired(o.ExpireAt)
 }
 
-func IsExpired(expireat uint64) bool {
+func IsExpired(expireat int64) bool {
 	return expireat != 0 && expireat <= nowms()
 }
 

--- a/pkg/store/set_test.go
+++ b/pkg/store/set_test.go
@@ -17,7 +17,7 @@ func (s *testStoreSuite) sdel(c *C, db uint32, key string, expect int64) {
 func (s *testStoreSuite) sdump(c *C, db uint32, key string, expect ...string) {
 	s.kexists(c, db, key, 1)
 
-	v, err := s.s.Dump(db, key)
+	v, err := s.s.Dump(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(v, NotNil)
 
@@ -42,7 +42,7 @@ func (s *testStoreSuite) srestore(c *C, db uint32, key string, ttlms int64, expe
 	dump, err := rdb.EncodeDump(x)
 	c.Assert(err, IsNil)
 
-	err = s.s.Restore(db, key, ttlms, dump)
+	err = s.s.Restore(db, FormatBytes(key, ttlms, dump))
 	c.Assert(err, IsNil)
 
 	s.sdump(c, db, key, expect...)
@@ -59,7 +59,7 @@ func (s *testStoreSuite) sadd(c *C, db uint32, key string, expect int64, members
 		args = append(args, m)
 	}
 
-	x, err := s.s.SAdd(db, args...)
+	x, err := s.s.SAdd(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -69,7 +69,7 @@ func (s *testStoreSuite) sadd(c *C, db uint32, key string, expect int64, members
 }
 
 func (s *testStoreSuite) scard(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.SCard(db, key)
+	x, err := s.s.SCard(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -81,7 +81,7 @@ func (s *testStoreSuite) scard(c *C, db uint32, key string, expect int64) {
 }
 
 func (s *testStoreSuite) smembers(c *C, db uint32, key string, expect ...string) {
-	x, err := s.s.SMembers(db, key)
+	x, err := s.s.SMembers(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(len(x), Equals, len(expect))
 
@@ -102,13 +102,13 @@ func (s *testStoreSuite) smembers(c *C, db uint32, key string, expect ...string)
 }
 
 func (s *testStoreSuite) sismember(c *C, db uint32, key, member string, expect int64) {
-	x, err := s.s.SIsMember(db, key, member)
+	x, err := s.s.SIsMember(db, FormatBytes(key, member))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) spop(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.SPop(db, key)
+	x, err := s.s.SPop(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 
 	if expect == 0 {
@@ -120,7 +120,7 @@ func (s *testStoreSuite) spop(c *C, db uint32, key string, expect int64) {
 }
 
 func (s *testStoreSuite) srandpop(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.SRandMember(db, key, 1)
+	x, err := s.s.SRandMember(db, FormatBytes(key, 1))
 	c.Assert(err, IsNil)
 
 	if expect == 0 {
@@ -140,7 +140,7 @@ func (s *testStoreSuite) srem(c *C, db uint32, key string, expect int64, members
 		args = append(args, m)
 	}
 
-	x, err := s.s.SRem(db, args...)
+	x, err := s.s.SRem(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 

--- a/pkg/store/slots.go
+++ b/pkg/store/slots.go
@@ -42,21 +42,25 @@ func HashKeyToSlot(key []byte) ([]byte, uint32) {
 }
 
 // SLOTSINFO [start] [count]
-func (s *Store) SlotsInfo(db uint32, args ...interface{}) (map[uint32]int64, error) {
+func (s *Store) SlotsInfo(db uint32, args [][]byte) (map[uint32]int64, error) {
 	if len(args) > 2 {
 		return nil, errArguments("len(args) = %d, expect <= 2", len(args))
 	}
 
-	var start, count uint32 = 0, MaxSlotNum
+	var start, count int64 = 0, MaxSlotNum
+	var err error
 	switch len(args) {
 	case 2:
-		if err := parseArgument(args[1], &count); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", 1, err)
+		count, err = ParseInt(args[1])
+		if err != nil {
+			return nil, errArguments("parse args failed - %s", err)
 		}
+
 		fallthrough
 	case 1:
-		if err := parseArgument(args[0], &start); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", 0, err)
+		start, err = ParseInt(args[0])
+		if err != nil {
+			return nil, errArguments("parse args failed - %s", err)
 		}
 	}
 	limit := start + count
@@ -67,7 +71,7 @@ func (s *Store) SlotsInfo(db uint32, args ...interface{}) (map[uint32]int64, err
 	defer s.release()
 
 	m := make(map[uint32]int64)
-	for slot := start; slot < limit && slot < MaxSlotNum; slot++ {
+	for slot := uint32(start); slot < uint32(limit) && slot < MaxSlotNum; slot++ {
 		if key, err := firstKeyUnderSlot(s, db, slot); err != nil {
 			return nil, err
 		} else if key != nil {
@@ -80,21 +84,21 @@ func (s *Store) SlotsInfo(db uint32, args ...interface{}) (map[uint32]int64, err
 }
 
 // SLOTSRESTORE key ttlms value [key ttlms value ...]
-func (s *Store) SlotsRestore(db uint32, args ...interface{}) error {
+func (s *Store) SlotsRestore(db uint32, args [][]byte) error {
 	if len(args) == 0 || len(args)%3 != 0 {
 		return errArguments("len(args) = %d, expect != 0 && mod 3 = 0", len(args))
 	}
 
 	objs := make([]*rdb.ObjEntry, len(args)/3)
 	for i := 0; i < len(objs); i++ {
-		var key, value []byte
-		var ttlms int64
-		for j, ref := range []interface{}{&key, &ttlms, &value} {
-			if err := parseArgument(args[i*3+j], ref); err != nil {
-				return errArguments("parse args[%d] failed, %s", i*3+j, err)
-			}
+		key := args[i*3]
+		value := args[i*3+1]
+		ttlms, err := ParseInt(args[i*3+2])
+		if err != nil {
+			return errArguments("parse args failed - %s", err)
 		}
-		expireat := uint64(0)
+
+		expireat := int64(0)
 		if ttlms != 0 {
 			if v, ok := TTLmsToExpireAt(ttlms); ok && v > 0 {
 				expireat = v
@@ -102,14 +106,16 @@ func (s *Store) SlotsRestore(db uint32, args ...interface{}) error {
 				return errArguments("parse args[%d] ttlms = %d", i*3+1, ttlms)
 			}
 		}
+
 		obj, err := rdb.DecodeDump(value)
 		if err != nil {
 			return errArguments("decode args[%d] failed, %s", i*3+2, err)
 		}
+
 		objs[i] = &rdb.ObjEntry{
 			DB:       db,
 			Key:      key,
-			ExpireAt: expireat,
+			ExpireAt: uint64(expireat),
 			Value:    obj,
 		}
 	}
@@ -129,7 +135,7 @@ func (s *Store) SlotsRestore(db uint32, args ...interface{}) error {
 		} else {
 			log.Debugf("[%d] restore batch, db = %d, key = %v", i, e.DB, e.Key)
 		}
-		if err := s.restore(bt, e.DB, e.Key, e.ExpireAt, e.Value); err != nil {
+		if err := s.restore(bt, e.DB, e.Key, int64(e.ExpireAt), e.Value); err != nil {
 			log.Warningf("restore object failed, db = %d, key = %v, err = %s", e.DB, e.Key, err)
 			return err
 		}
@@ -140,20 +146,25 @@ func (s *Store) SlotsRestore(db uint32, args ...interface{}) error {
 }
 
 // SLOTSMGRTSLOT host port timeout slot
-func (s *Store) SlotsMgrtSlot(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) SlotsMgrtSlot(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 4 {
 		return 0, errArguments("len(args) = %d, expect = 4", len(args))
 	}
 
-	var host string
-	var port int64
-	var ttlms uint64
-	var slot uint32
-	for i, ref := range []interface{}{&host, &port, &ttlms, &slot} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	host := string(args[0])
+	port, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+	ttlms, err := ParseInt(args[2])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+	slot, err := ParseUint(args[3])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+
 	var timeout = time.Duration(ttlms) * time.Millisecond
 	if slot >= MaxSlotNum {
 		return 0, errArguments("slot = %d", slot)
@@ -170,7 +181,7 @@ func (s *Store) SlotsMgrtSlot(db uint32, args ...interface{}) (int64, error) {
 
 	log.Debugf("migrate slot, addr = %s, timeout = %d, db = %d, slot = %d", addr, timeout, db, slot)
 
-	key, err := firstKeyUnderSlot(s, db, slot)
+	key, err := firstKeyUnderSlot(s, db, uint32(slot))
 	if err != nil || key == nil {
 		return 0, err
 	}
@@ -178,20 +189,25 @@ func (s *Store) SlotsMgrtSlot(db uint32, args ...interface{}) (int64, error) {
 }
 
 // SLOTSMGRTTAGSLOT host port timeout slot
-func (s *Store) SlotsMgrtTagSlot(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) SlotsMgrtTagSlot(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 4 {
 		return 0, errArguments("len(args) = %d, expect = 4", len(args))
 	}
 
-	var host string
-	var port int64
-	var ttlms uint64
-	var slot uint32
-	for i, ref := range []interface{}{&host, &port, &ttlms, &slot} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	host := string(args[0])
+	port, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+	ttlms, err := ParseInt(args[2])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+	slot, err := ParseUint(args[3])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+
 	var timeout = time.Duration(ttlms) * time.Millisecond
 	if slot >= MaxSlotNum {
 		return 0, errArguments("slot = %d", slot)
@@ -208,7 +224,7 @@ func (s *Store) SlotsMgrtTagSlot(db uint32, args ...interface{}) (int64, error) 
 
 	log.Debugf("migrate slot with tag, addr = %s, timeout = %d, db = %d, slot = %d", addr, timeout, db, slot)
 
-	key, err := firstKeyUnderSlot(s, db, slot)
+	key, err := firstKeyUnderSlot(s, db, uint32(slot))
 	if err != nil || key == nil {
 		return 0, err
 	}
@@ -221,20 +237,22 @@ func (s *Store) SlotsMgrtTagSlot(db uint32, args ...interface{}) (int64, error) 
 }
 
 // SLOTSMGRTONE host port timeout key
-func (s *Store) SlotsMgrtOne(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) SlotsMgrtOne(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 4 {
 		return 0, errArguments("len(args) = %d, expect = 4", len(args))
 	}
 
-	var host string
-	var port int64
-	var ttlms uint64
-	var key []byte
-	for i, ref := range []interface{}{&host, &port, &ttlms, &key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	host := string(args[0])
+	port, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+	ttlms, err := ParseInt(args[2])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+	key := args[3]
+
 	var timeout = time.Duration(ttlms) * time.Millisecond
 	if timeout == 0 {
 		timeout = time.Second
@@ -252,20 +270,22 @@ func (s *Store) SlotsMgrtOne(db uint32, args ...interface{}) (int64, error) {
 }
 
 // SLOTSMGRTTAGONE host port timeout key
-func (s *Store) SlotsMgrtTagOne(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) SlotsMgrtTagOne(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 4 {
 		return 0, errArguments("len(args) = %d, expect = 4", len(args))
 	}
 
-	var host string
-	var port int64
-	var ttlms uint64
-	var key []byte
-	for i, ref := range []interface{}{&host, &port, &ttlms, &key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	host := string(args[0])
+	port, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+	ttlms, err := ParseInt(args[2])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+	key := args[3]
+
 	var timeout = time.Duration(ttlms) * time.Millisecond
 	if timeout == 0 {
 		timeout = time.Second

--- a/pkg/store/slots.go
+++ b/pkg/store/slots.go
@@ -92,11 +92,11 @@ func (s *Store) SlotsRestore(db uint32, args [][]byte) error {
 	objs := make([]*rdb.ObjEntry, len(args)/3)
 	for i := 0; i < len(objs); i++ {
 		key := args[i*3]
-		value := args[i*3+1]
-		ttlms, err := ParseInt(args[i*3+2])
+		ttlms, err := ParseInt(args[i*3+1])
 		if err != nil {
 			return errArguments("parse args failed - %s", err)
 		}
+		value := args[i*3+2]
 
 		expireat := int64(0)
 		if ttlms != 0 {

--- a/pkg/store/slots_test.go
+++ b/pkg/store/slots_test.go
@@ -138,12 +138,12 @@ func (s *testStoreSuite) xslotsrestore(c *C, db uint32, args ...interface{}) {
 		}
 	}
 
-	err := s.s.SlotsRestore(db, x...)
+	err := s.s.SlotsRestore(db, FormatBytes(x...))
 	c.Assert(err, IsNil)
 }
 
 func (s *testStoreSuite) slotsinfo(c *C, db uint32, sum int64) {
-	m, err := s.s.SlotsInfo(db)
+	m, err := s.s.SlotsInfo(db, [][]byte{})
 	c.Assert(err, IsNil)
 	c.Assert(m, NotNil)
 
@@ -158,7 +158,7 @@ func (s *testStoreSuite) slotsmgrtslot(addr *net.TCPAddr, db uint32, tag string,
 	c := make(chan error, 1)
 	go func() {
 		host, port := addr.IP.String(), addr.Port
-		n, err := s.s.SlotsMgrtSlot(db, host, port, 1000, HashTagToSlot([]byte(tag)))
+		n, err := s.s.SlotsMgrtSlot(db, FormatBytes(host, port, 1000, HashTagToSlot([]byte(tag))))
 		if err != nil {
 			c <- err
 		} else if n != expect {
@@ -174,7 +174,7 @@ func (s *testStoreSuite) slotsmgrttagslot(addr *net.TCPAddr, db uint32, tag stri
 	c := make(chan error, 1)
 	go func() {
 		host, port := addr.IP.String(), addr.Port
-		n, err := s.s.SlotsMgrtTagSlot(db, host, port, 1000, HashTagToSlot([]byte(tag)))
+		n, err := s.s.SlotsMgrtTagSlot(db, FormatBytes(host, port, 1000, HashTagToSlot([]byte(tag))))
 		if err != nil {
 			c <- err
 		} else if n != expect {
@@ -190,7 +190,7 @@ func (s *testStoreSuite) slotsmgrtone(addr *net.TCPAddr, db uint32, key string, 
 	c := make(chan error, 1)
 	go func() {
 		host, port := addr.IP.String(), addr.Port
-		n, err := s.s.SlotsMgrtOne(db, host, port, 1000, []byte(key))
+		n, err := s.s.SlotsMgrtOne(db, FormatBytes(host, port, 1000, []byte(key)))
 		if err != nil {
 			c <- err
 		} else if n != expect {
@@ -206,7 +206,7 @@ func (s *testStoreSuite) slotsmgrttagone(addr *net.TCPAddr, db uint32, key strin
 	c := make(chan error, 1)
 	go func() {
 		host, port := addr.IP.String(), addr.Port
-		n, err := s.s.SlotsMgrtTagOne(db, host, port, 1000, []byte(key))
+		n, err := s.s.SlotsMgrtTagOne(db, FormatBytes(host, port, 1000, []byte(key)))
 		if err != nil {
 			c <- err
 		} else if n != expect {

--- a/pkg/store/snapshot_test.go
+++ b/pkg/store/snapshot_test.go
@@ -27,7 +27,7 @@ func (s *testStoreSuite) TestSnapshot(c *C) {
 			ss = append(ss, k, v)
 		}
 		s.hmset(c, db, "hash", ss...)
-		s.kpexpireat(c, db, "hash", now+1000*uint64(db+37), 1)
+		s.kpexpireat(c, db, "hash", now+1000*int64(db+37), 1)
 	}
 
 	sleepms(20)
@@ -51,7 +51,7 @@ func (s *testStoreSuite) TestSnapshot(c *C) {
 			}
 			ok = true
 			c.Assert(string(obj.Key), Equals, "hash")
-			c.Assert(obj.ExpireAt, Equals, now+uint64(db+37)*1000)
+			c.Assert(obj.ExpireAt, Equals, now+int64(db+37)*1000)
 
 			x := obj.Value.(rdb.Hash)
 			c.Assert(err, IsNil)

--- a/pkg/store/snapshot_test.go
+++ b/pkg/store/snapshot_test.go
@@ -51,7 +51,7 @@ func (s *testStoreSuite) TestSnapshot(c *C) {
 			}
 			ok = true
 			c.Assert(string(obj.Key), Equals, "hash")
-			c.Assert(obj.ExpireAt, Equals, now+int64(db+37)*1000)
+			c.Assert(int64(obj.ExpireAt), Equals, now+int64(db+37)*1000)
 
 			x := obj.Value.(rdb.Hash)
 			c.Assert(err, IsNil)

--- a/pkg/store/string.go
+++ b/pkg/store/string.go
@@ -36,7 +36,7 @@ func (o *stringRow) deleteObject(s *Store, bt *engine.Batch) error {
 	return nil
 }
 
-func (o *stringRow) storeObject(s *Store, bt *engine.Batch, expireat uint64, obj interface{}) error {
+func (o *stringRow) storeObject(s *Store, bt *engine.Batch, expireat int64, obj interface{}) error {
 	value, ok := obj.(rdb.String)
 	if !ok || len(value) == 0 {
 		return errors.Trace(ErrObjectValue)
@@ -71,17 +71,12 @@ func (s *Store) loadStringRow(db uint32, key []byte, deleteIfExpired bool) (*str
 }
 
 // GET key
-func (s *Store) Get(db uint32, args ...interface{}) ([]byte, error) {
+func (s *Store) Get(db uint32, args [][]byte) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -102,17 +97,13 @@ func (s *Store) Get(db uint32, args ...interface{}) ([]byte, error) {
 }
 
 // APPEND key value
-func (s *Store) Append(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Append(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, value []byte
-	for i, ref := range []interface{}{&key, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	value := args[1]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -136,23 +127,20 @@ func (s *Store) Append(db uint32, args ...interface{}) (int64, error) {
 		o.Value = value
 		bt.Set(o.MetaKey(), o.MetaValue())
 	}
+
 	bt.Set(o.DataKey(), o.DataValue())
 	fw := &Forward{DB: db, Op: "Append", Args: args}
 	return int64(len(o.Value)), s.commit(bt, fw)
 }
 
 // SET key value
-func (s *Store) Set(db uint32, args ...interface{}) error {
+func (s *Store) Set(db uint32, args [][]byte) error {
 	if len(args) != 2 {
 		return errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, value []byte
-	for i, ref := range []interface{}{&key, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	value := args[1]
 
 	if err := s.acquire(); err != nil {
 		return err
@@ -164,6 +152,7 @@ func (s *Store) Set(db uint32, args ...interface{}) error {
 	if err != nil {
 		return err
 	}
+
 	o := newStringRow(db, key)
 	o.Value = value
 	bt.Set(o.DataKey(), o.DataValue())
@@ -173,22 +162,23 @@ func (s *Store) Set(db uint32, args ...interface{}) error {
 }
 
 // PSETEX key milliseconds value
-func (s *Store) PSetEX(db uint32, args ...interface{}) error {
+func (s *Store) PSetEX(db uint32, args [][]byte) error {
 	if len(args) != 3 {
 		return errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key, value []byte
-	var ttlms int64
-	for i, ref := range []interface{}{&key, &ttlms, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	ttlms, err := ParseInt(args[1])
+	if err != nil {
+		return errArguments("parse args failed - %s", err)
 	}
+	value := args[2]
+
 	if ttlms == 0 {
 		return errArguments("invalid ttlms = %d", ttlms)
 	}
-	expireat := uint64(0)
+
+	expireat := int64(0)
 	if v, ok := TTLmsToExpireAt(ttlms); ok && v > 0 {
 		expireat = v
 	} else {
@@ -201,10 +191,11 @@ func (s *Store) PSetEX(db uint32, args ...interface{}) error {
 	defer s.release()
 
 	bt := engine.NewBatch()
-	_, err := s.deleteIfExists(bt, db, key)
+	_, err = s.deleteIfExists(bt, db, key)
 	if err != nil {
 		return err
 	}
+
 	if !IsExpired(expireat) {
 		o := newStringRow(db, key)
 		o.ExpireAt, o.Value = expireat, value
@@ -213,28 +204,28 @@ func (s *Store) PSetEX(db uint32, args ...interface{}) error {
 		fw := &Forward{DB: db, Op: "PSetEX", Args: args}
 		return s.commit(bt, fw)
 	} else {
-		fw := &Forward{DB: db, Op: "Del", Args: []interface{}{key}}
+		fw := &Forward{DB: db, Op: "Del", Args: [][]byte{key}}
 		return s.commit(bt, fw)
 	}
 }
 
 // SETEX key seconds value
-func (s *Store) SetEX(db uint32, args ...interface{}) error {
+func (s *Store) SetEX(db uint32, args [][]byte) error {
 	if len(args) != 3 {
 		return errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key, value []byte
-	var ttls int64
-	for i, ref := range []interface{}{&key, &ttls, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	ttls, err := ParseInt(args[1])
+	if err != nil {
+		return errArguments("parse args failed - %s", err)
 	}
+	value := args[2]
+
 	if ttls == 0 {
 		return errArguments("invalid ttls = %d", ttls)
 	}
-	expireat := uint64(0)
+	expireat := int64(0)
 	if v, ok := TTLsToExpireAt(ttls); ok && v > 0 {
 		expireat = v
 	} else {
@@ -247,7 +238,7 @@ func (s *Store) SetEX(db uint32, args ...interface{}) error {
 	defer s.release()
 
 	bt := engine.NewBatch()
-	_, err := s.deleteIfExists(bt, db, key)
+	_, err = s.deleteIfExists(bt, db, key)
 	if err != nil {
 		return err
 	}
@@ -259,23 +250,19 @@ func (s *Store) SetEX(db uint32, args ...interface{}) error {
 		fw := &Forward{DB: db, Op: "SetEX", Args: args}
 		return s.commit(bt, fw)
 	} else {
-		fw := &Forward{DB: db, Op: "Del", Args: []interface{}{key}}
+		fw := &Forward{DB: db, Op: "Del", Args: [][]byte{key}}
 		return s.commit(bt, fw)
 	}
 }
 
 // SETNX key value
-func (s *Store) SetNX(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) SetNX(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, value []byte
-	for i, ref := range []interface{}{&key, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	value := args[1]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -297,17 +284,13 @@ func (s *Store) SetNX(db uint32, args ...interface{}) (int64, error) {
 }
 
 // GETSET key value
-func (s *Store) GetSet(db uint32, args ...interface{}) ([]byte, error) {
+func (s *Store) GetSet(db uint32, args [][]byte) ([]byte, error) {
 	if len(args) != 2 {
 		return nil, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, value []byte
-	for i, ref := range []interface{}{&key, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	value := args[1]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -334,6 +317,7 @@ func (s *Store) GetSet(db uint32, args ...interface{}) ([]byte, error) {
 		o = newStringRow(db, key)
 		bt.Set(o.MetaKey(), o.MetaValue())
 	}
+
 	o.Value, value = value, o.Value
 	bt.Set(o.DataKey(), o.DataValue())
 	fw := &Forward{DB: db, Op: "Set", Args: args}
@@ -361,9 +345,10 @@ func (s *Store) incrInt(db uint32, key []byte, delta int64) (int64, error) {
 		o = newStringRow(db, key)
 		bt.Set(o.MetaKey(), o.MetaValue())
 	}
+
 	o.Value = FormatInt(delta)
 	bt.Set(o.DataKey(), o.DataValue())
-	fw := &Forward{DB: db, Op: "IncrBy", Args: []interface{}{key, delta}}
+	fw := &Forward{DB: db, Op: "IncrBy", Args: [][]byte{key, FormatInt(delta)}}
 	return delta, s.commit(bt, fw)
 }
 
@@ -395,22 +380,17 @@ func (s *Store) incrFloat(db uint32, key []byte, delta float64) (float64, error)
 
 	o.Value = FormatFloat(delta)
 	bt.Set(o.DataKey(), o.DataValue())
-	fw := &Forward{DB: db, Op: "IncrByFloat", Args: []interface{}{key, delta}}
+	fw := &Forward{DB: db, Op: "IncrByFloat", Args: [][]byte{key, FormatFloat(delta)}}
 	return delta, s.commit(bt, fw)
 }
 
 // INCR key
-func (s *Store) Incr(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Incr(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -421,17 +401,15 @@ func (s *Store) Incr(db uint32, args ...interface{}) (int64, error) {
 }
 
 // INCRBY key delta
-func (s *Store) IncrBy(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) IncrBy(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var delta int64
-	for i, ref := range []interface{}{&key, &delta} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	delta, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -443,17 +421,12 @@ func (s *Store) IncrBy(db uint32, args ...interface{}) (int64, error) {
 }
 
 // DECR key
-func (s *Store) Decr(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Decr(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -464,17 +437,15 @@ func (s *Store) Decr(db uint32, args ...interface{}) (int64, error) {
 }
 
 // DECRBY key delta
-func (s *Store) DecrBy(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) DecrBy(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var delta int64
-	for i, ref := range []interface{}{&key, &delta} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	delta, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -486,17 +457,15 @@ func (s *Store) DecrBy(db uint32, args ...interface{}) (int64, error) {
 }
 
 // INCRBYFLOAT key delta
-func (s *Store) IncrByFloat(db uint32, args ...interface{}) (float64, error) {
+func (s *Store) IncrByFloat(db uint32, args [][]byte) (float64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var delta float64
-	for i, ref := range []interface{}{&key, &delta} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	delta, err := ParseFloat(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -508,18 +477,21 @@ func (s *Store) IncrByFloat(db uint32, args ...interface{}) (float64, error) {
 }
 
 // SETBIT key offset value
-func (s *Store) SetBit(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) SetBit(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key []byte
-	var offset, value uint64
-	for i, ref := range []interface{}{&key, &offset, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	offset, err := ParseUint(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+	value, err := ParseUint(args[2])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+
 	if offset > maxVarbytesLen {
 		return 0, errArguments("offset = %d", offset)
 	}
@@ -568,18 +540,18 @@ func (s *Store) SetBit(db uint32, args ...interface{}) (int64, error) {
 }
 
 // SETRANGE key offset value
-func (s *Store) SetRange(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) SetRange(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key, value []byte
-	var offset uint64
-	for i, ref := range []interface{}{&key, &offset, &value} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	offset, err := ParseUint(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+	value := args[2]
+
 	if offset > maxVarbytesLen {
 		return 0, errArguments("offset = %d", offset)
 	}
@@ -614,16 +586,9 @@ func (s *Store) SetRange(db uint32, args ...interface{}) (int64, error) {
 }
 
 // MSET key value [key value ...]
-func (s *Store) MSet(db uint32, args ...interface{}) error {
+func (s *Store) MSet(db uint32, args [][]byte) error {
 	if len(args) == 0 || len(args)%2 != 0 {
 		return errArguments("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
-	}
-
-	pairs := make([][]byte, len(args))
-	for i := 0; i < len(args); i++ {
-		if err := parseArgument(args[i], &pairs[i]); err != nil {
-			return errArguments("parse args[%d] failed, %s", i, err)
-		}
 	}
 
 	if err := s.acquire(); err != nil {
@@ -633,8 +598,8 @@ func (s *Store) MSet(db uint32, args ...interface{}) error {
 
 	ms := &markSet{}
 	bt := engine.NewBatch()
-	for i := len(pairs)/2 - 1; i >= 0; i-- {
-		key, value := pairs[i*2], pairs[i*2+1]
+	for i := len(args)/2 - 1; i >= 0; i-- {
+		key, value := args[i*2], args[i*2+1]
 		if !ms.Has(key) {
 			_, err := s.deleteIfExists(bt, db, key)
 			if err != nil {
@@ -652,16 +617,9 @@ func (s *Store) MSet(db uint32, args ...interface{}) error {
 }
 
 // MSETNX key value [key value ...]
-func (s *Store) MSetNX(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) MSetNX(db uint32, args [][]byte) (int64, error) {
 	if len(args) == 0 || len(args)%2 != 0 {
 		return 0, errArguments("len(args) = %d, expect != 0 && mod 2 = 0", len(args))
-	}
-
-	pairs := make([][]byte, len(args))
-	for i := 0; i < len(args); i++ {
-		if err := parseArgument(args[i], &pairs[i]); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
 	}
 
 	if err := s.acquire(); err != nil {
@@ -669,8 +627,8 @@ func (s *Store) MSetNX(db uint32, args ...interface{}) (int64, error) {
 	}
 	defer s.release()
 
-	for i := 0; i < len(pairs); i += 2 {
-		o, err := s.loadStoreRow(db, pairs[i], true)
+	for i := 0; i < len(args); i += 2 {
+		o, err := s.loadStoreRow(db, args[i], true)
 		if err != nil || o != nil {
 			return 0, err
 		}
@@ -678,8 +636,8 @@ func (s *Store) MSetNX(db uint32, args ...interface{}) (int64, error) {
 
 	ms := &markSet{}
 	bt := engine.NewBatch()
-	for i := len(pairs)/2 - 1; i >= 0; i-- {
-		key, value := pairs[i*2], pairs[i*2+1]
+	for i := len(args)/2 - 1; i >= 0; i-- {
+		key, value := args[i*2], args[i*2+1]
 		if !ms.Has(key) {
 			o := newStringRow(db, key)
 			o.Value = value
@@ -693,17 +651,12 @@ func (s *Store) MSetNX(db uint32, args ...interface{}) (int64, error) {
 }
 
 // MGET key [key ...]
-func (s *Store) MGet(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) MGet(db uint32, args [][]byte) ([][]byte, error) {
 	if len(args) == 0 {
 		return nil, errArguments("len(args) = %d, expect != 0", len(args))
 	}
 
-	keys := make([][]byte, len(args))
-	for i := 0; i < len(args); i++ {
-		if err := parseArgument(args[i], &keys[i]); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	keys := args
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -736,18 +689,17 @@ func (s *Store) MGet(db uint32, args ...interface{}) ([][]byte, error) {
 }
 
 // GETBIT key offset
-func (s *Store) GetBit(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) GetBit(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key []byte
-	var offset uint64
-	for i, ref := range []interface{}{&key, &offset} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	offset, err := ParseUint(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+
 	if offset > maxVarbytesLen {
 		return 0, errArguments("offset = %d", offset)
 	}
@@ -780,17 +732,19 @@ func (s *Store) GetBit(db uint32, args ...interface{}) (int64, error) {
 }
 
 // GETRANGE key beg end
-func (s *Store) GetRange(db uint32, args ...interface{}) ([]byte, error) {
+func (s *Store) GetRange(db uint32, args [][]byte) ([]byte, error) {
 	if len(args) != 3 {
 		return nil, errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key []byte
-	var beg, end int64
-	for i, ref := range []interface{}{&key, &beg, &end} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	beg, err := ParseInt(args[1])
+	if err != nil {
+		return nil, errArguments("parse args failed - %s", err)
+	}
+	end, err := ParseInt(args[1])
+	if err != nil {
+		return nil, errArguments("parse args failed - %s", err)
 	}
 
 	if err := s.acquire(); err != nil {
@@ -843,17 +797,12 @@ func maxIntValue(v1, v2 int64) int64 {
 }
 
 // STRLEN key
-func (s *Store) Strlen(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) Strlen(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err

--- a/pkg/store/string.go
+++ b/pkg/store/string.go
@@ -742,7 +742,7 @@ func (s *Store) GetRange(db uint32, args [][]byte) ([]byte, error) {
 	if err != nil {
 		return nil, errArguments("parse args failed - %s", err)
 	}
-	end, err := ParseInt(args[1])
+	end, err := ParseInt(args[2])
 	if err != nil {
 		return nil, errArguments("parse args failed - %s", err)
 	}

--- a/pkg/store/string_test.go
+++ b/pkg/store/string_test.go
@@ -19,7 +19,7 @@ func (s *testStoreSuite) xdel(c *C, db uint32, key string, expect int64) {
 func (s *testStoreSuite) xdump(c *C, db uint32, key string, expect string) {
 	s.kexists(c, db, key, 1)
 
-	v, err := s.s.Dump(db, key)
+	v, err := s.s.Dump(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(v, NotNil)
 
@@ -35,7 +35,7 @@ func (s *testStoreSuite) xrestore(c *C, db uint32, key string, ttlms uint64, val
 	dump, err := rdb.EncodeDump(x)
 	c.Assert(err, IsNil)
 
-	err = s.s.Restore(db, key, ttlms, dump)
+	err = s.s.Restore(db, FormatBytes(key, ttlms, dump))
 	c.Assert(err, IsNil)
 
 	s.xdump(c, db, key, value)
@@ -47,7 +47,7 @@ func (s *testStoreSuite) xrestore(c *C, db uint32, key string, ttlms uint64, val
 }
 
 func (s *testStoreSuite) xset(c *C, db uint32, key, value string) {
-	err := s.s.Set(db, []byte(key), []byte(value))
+	err := s.s.Set(db, FormatBytes(key, value))
 	c.Assert(err, IsNil)
 
 	s.kttl(c, db, key, -1)
@@ -55,7 +55,7 @@ func (s *testStoreSuite) xset(c *C, db uint32, key, value string) {
 }
 
 func (s *testStoreSuite) xget(c *C, db uint32, key string, expect string) {
-	x, err := s.s.Get(db, []byte(key))
+	x, err := s.s.Get(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 
 	if expect == "" {
@@ -68,13 +68,13 @@ func (s *testStoreSuite) xget(c *C, db uint32, key string, expect string) {
 }
 
 func (s *testStoreSuite) xappend(c *C, db uint32, key, value string, expect int64) {
-	x, err := s.s.Append(db, key, value)
+	x, err := s.s.Append(db, FormatBytes(key, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) xgetset(c *C, db uint32, key, value string, expect string) {
-	x, err := s.s.GetSet(db, key, value)
+	x, err := s.s.GetSet(db, FormatBytes(key, value))
 	c.Assert(err, IsNil)
 
 	if expect == "" {
@@ -87,7 +87,7 @@ func (s *testStoreSuite) xgetset(c *C, db uint32, key, value string, expect stri
 }
 
 func (s *testStoreSuite) xpsetex(c *C, db uint32, key, value string, ttlms uint64) {
-	err := s.s.PSetEX(db, key, ttlms, value)
+	err := s.s.PSetEX(db, FormatBytes(key, ttlms, value))
 	c.Assert(err, IsNil)
 
 	s.xdump(c, db, key, value)
@@ -95,7 +95,7 @@ func (s *testStoreSuite) xpsetex(c *C, db uint32, key, value string, ttlms uint6
 }
 
 func (s *testStoreSuite) xsetex(c *C, db uint32, key, value string, ttls uint64) {
-	err := s.s.SetEX(db, key, ttls, value)
+	err := s.s.SetEX(db, FormatBytes(key, ttls, value))
 	c.Assert(err, IsNil)
 
 	s.xdump(c, db, key, value)
@@ -103,7 +103,7 @@ func (s *testStoreSuite) xsetex(c *C, db uint32, key, value string, ttls uint64)
 }
 
 func (s *testStoreSuite) xsetnx(c *C, db uint32, key, value string, expect int64) {
-	x, err := s.s.SetNX(db, key, value)
+	x, err := s.s.SetNX(db, FormatBytes(key, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -120,43 +120,43 @@ func (s *testStoreSuite) xstrlen(c *C, db uint32, key string, expect int64) {
 		s.kexists(c, db, key, 0)
 	}
 
-	x, err := s.s.Strlen(db, key)
+	x, err := s.s.Strlen(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) xincr(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.Incr(db, key)
+	x, err := s.s.Incr(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) xdecr(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.Decr(db, key)
+	x, err := s.s.Decr(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) xincrby(c *C, db uint32, key string, delta int64, expect int64) {
-	x, err := s.s.IncrBy(db, key, delta)
+	x, err := s.s.IncrBy(db, FormatBytes(key, delta))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) xdecrby(c *C, db uint32, key string, delta int64, expect int64) {
-	x, err := s.s.DecrBy(db, key, delta)
+	x, err := s.s.DecrBy(db, FormatBytes(key, delta))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) xincrbyfloat(c *C, db uint32, key string, delta float64, expect float64) {
-	x, err := s.s.IncrByFloat(db, key, delta)
+	x, err := s.s.IncrByFloat(db, FormatBytes(key, delta))
 	c.Assert(err, IsNil)
 	c.Assert(math.Abs(x-expect) < 1e-9, Equals, true)
 }
 
 func (s *testStoreSuite) xsetbit(c *C, db uint32, key string, offset uint, value int64, expect int64) {
-	x, err := s.s.SetBit(db, key, offset, value)
+	x, err := s.s.SetBit(db, FormatBytes(key, offset, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -164,13 +164,13 @@ func (s *testStoreSuite) xsetbit(c *C, db uint32, key string, offset uint, value
 }
 
 func (s *testStoreSuite) xgetbit(c *C, db uint32, key string, offset uint, expect int64) {
-	x, err := s.s.GetBit(db, key, offset)
+	x, err := s.s.GetBit(db, FormatBytes(key, offset))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) xsetrange(c *C, db uint32, key string, offset uint, value string, expect int64) {
-	x, err := s.s.SetRange(db, key, offset, value)
+	x, err := s.s.SetRange(db, FormatBytes(key, offset, value))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -178,7 +178,7 @@ func (s *testStoreSuite) xsetrange(c *C, db uint32, key string, offset uint, val
 }
 
 func (s *testStoreSuite) xgetrange(c *C, db uint32, key string, beg, end int, expect string) {
-	x, err := s.s.GetRange(db, key, beg, end)
+	x, err := s.s.GetRange(db, FormatBytes(key, beg, end))
 	c.Assert(err, IsNil)
 	c.Assert(string(x), Equals, expect)
 }
@@ -189,7 +189,7 @@ func (s *testStoreSuite) xmset(c *C, db uint32, pairs ...string) {
 		args[i] = s
 	}
 
-	err := s.s.MSet(db, args...)
+	err := s.s.MSet(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 
 	m := make(map[string]string)
@@ -208,7 +208,7 @@ func (s *testStoreSuite) xmsetnx(c *C, db uint32, expect int64, pairs ...string)
 		args[i] = s
 	}
 
-	x, err := s.s.MSetNX(db, args...)
+	x, err := s.s.MSetNX(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -234,7 +234,7 @@ func (s *testStoreSuite) xmget(c *C, db uint32, pairs ...string) {
 		args = append(args, pairs[i])
 	}
 
-	x, err := s.s.MGet(db, args...)
+	x, err := s.s.MGet(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(len(x), Equals, len(args))
 
@@ -406,10 +406,10 @@ func (s *testStoreSuite) TestXIncrByFloat(c *C) {
 		s.xincrbyfloat(c, 0, "string", a, sum)
 	}
 
-	_, err := s.s.IncrByFloat(0, "string", math.Inf(1))
+	_, err := s.s.IncrByFloat(0, FormatBytes("string", math.Inf(1)))
 	c.Assert(err, NotNil)
 
-	_, err = s.s.IncrByFloat(0, "string", math.Inf(-1))
+	_, err = s.s.IncrByFloat(0, FormatBytes("string", math.Inf(-1)))
 	c.Assert(err, NotNil)
 
 	s.xdel(c, 0, "string", 1)

--- a/pkg/store/zset.go
+++ b/pkg/store/zset.go
@@ -138,7 +138,7 @@ func (o *zsetRow) deleteObject(s *Store, bt *engine.Batch) error {
 	return it.Error()
 }
 
-func (o *zsetRow) storeObject(s *Store, bt *engine.Batch, expireat uint64, obj interface{}) error {
+func (o *zsetRow) storeObject(s *Store, bt *engine.Batch, expireat int64, obj interface{}) error {
 	zset, ok := obj.(rdb.ZSet)
 	if !ok || len(zset) == 0 {
 		return errors.Trace(ErrObjectValue)
@@ -210,17 +210,12 @@ func (s *Store) loadZSetRow(db uint32, key []byte, deleteIfExpired bool) (*zsetR
 }
 
 // ZGETALL key
-func (s *Store) ZGetAll(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) ZGetAll(db uint32, args [][]byte) ([][]byte, error) {
 	if len(args) != 1 {
 		return nil, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return nil, err
@@ -246,17 +241,12 @@ func (s *Store) ZGetAll(db uint32, args ...interface{}) ([][]byte, error) {
 }
 
 // ZCARD key
-func (s *Store) ZCard(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZCard(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 1 {
 		return 0, errArguments("len(args) = %d, expect = 1", len(args))
 	}
 
-	var key []byte
-	for i, ref := range []interface{}{&key} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -271,28 +261,28 @@ func (s *Store) ZCard(db uint32, args ...interface{}) (int64, error) {
 }
 
 // ZADD key score member [score member ...]
-func (s *Store) ZAdd(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZAdd(db uint32, args [][]byte) (int64, error) {
 	if len(args) == 1 || len(args)%2 != 1 {
 		return 0, errArguments("len(args) = %d, expect != 1 && mod 2 = 1", len(args))
 	}
 
-	var key []byte
+	key := args[0]
+
 	var eles = make([]struct {
 		Member []byte
 		Score  float64
 	}, len(args)/2)
-	if err := parseArgument(args[0], &key); err != nil {
-		return 0, errArguments("parse args[%d] failed, %s", 0, err)
-	}
+
+	var err error
 	for i := 0; i < len(eles); i++ {
 		e := &eles[i]
-		if err := parseArgument(args[i*2+1], &e.Score); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i*2+1, err)
+		e.Score, err = ParseFloat(args[i*2+1])
+		if err != nil {
+			return 0, errArguments("parse args failed - %s", err)
 		}
 
-		if err := parseArgument(args[i*2+2], &e.Member); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i*2+2, err)
-		} else if len(e.Member) == 0 {
+		e.Member = args[i*2+2]
+		if len(e.Member) == 0 {
 			return 0, errArguments("parse args[%d] failed, empty empty", i*2+2)
 		}
 	}
@@ -342,21 +332,13 @@ func (s *Store) ZAdd(db uint32, args ...interface{}) (int64, error) {
 }
 
 // ZREM key member [member ...]
-func (s *Store) ZRem(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZRem(db uint32, args [][]byte) (int64, error) {
 	if len(args) < 2 {
 		return 0, errArguments("len(args) = %d, expect >= 2", len(args))
 	}
 
-	var key []byte
-	var members = make([][]byte, len(args)-1)
-	if err := parseArgument(args[0], &key); err != nil {
-		return 0, errArguments("parse args[%d] failed, %s", 0, err)
-	}
-	for i := 0; i < len(members); i++ {
-		if err := parseArgument(args[i+1], &members[i]); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i+1, err)
-		}
-	}
+	key := args[0]
+	members := args[1:]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -397,17 +379,13 @@ func (s *Store) ZRem(db uint32, args ...interface{}) (int64, error) {
 }
 
 // ZSCORE key member
-func (s *Store) ZScore(db uint32, args ...interface{}) (float64, bool, error) {
+func (s *Store) ZScore(db uint32, args [][]byte) (float64, bool, error) {
 	if len(args) != 2 {
 		return 0, false, errArguments("len(args) = %d, expect = 2", len(args))
 	}
 
-	var key, member []byte
-	for i, ref := range []interface{}{&key, &member} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, false, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	member := args[1]
 
 	if err := s.acquire(); err != nil {
 		return 0, false, err
@@ -429,18 +407,17 @@ func (s *Store) ZScore(db uint32, args ...interface{}) (float64, bool, error) {
 }
 
 // ZINCRBY key delta member
-func (s *Store) ZIncrBy(db uint32, args ...interface{}) (float64, error) {
+func (s *Store) ZIncrBy(db uint32, args [][]byte) (float64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key, member []byte
-	var delta float64
-	for i, ref := range []interface{}{&key, &delta, &member} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	delta, err := ParseFloat(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
+	member := args[2]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -654,19 +631,14 @@ func (o *zsetRow) reverseTravelInRange(s *Store, r *rangeSpec, f func(o *zsetRow
 }
 
 // ZCOUNT key min max
-func (s *Store) ZCount(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZCount(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key []byte
-	var min []byte
-	var max []byte
-	for i, ref := range []interface{}{&key, &min, &max} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	min := args[1]
+	max := args[2]
 
 	r, err := parseRangeSpec(min, max)
 	if err != nil {
@@ -916,19 +888,14 @@ func (o *zsetRow) reverseTravelInLexRange(s *Store, r *lexRangeSpec, f func(o *z
 }
 
 // ZLEXCOUNT key min max
-func (s *Store) ZLexCount(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZLexCount(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect = 3", len(args))
 	}
 
-	var key []byte
-	var min []byte
-	var max []byte
-	for i, ref := range []interface{}{&key, &min, &max} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	min := args[1]
+	max := args[2]
 
 	r, err := parseLexRangeSpec(min, max)
 	if err != nil {
@@ -958,18 +925,19 @@ func (s *Store) ZLexCount(db uint32, args ...interface{}) (int64, error) {
 	return count, nil
 }
 
-func (s *Store) genericZRange(db uint32, args []interface{}, reverse bool) ([][]byte, error) {
+func (s *Store) genericZRange(db uint32, args [][]byte, reverse bool) ([][]byte, error) {
 	if len(args) != 3 && len(args) != 4 {
 		return nil, errArguments("len(args) = %d, expect = 3/4", len(args))
 	}
 
-	var key []byte
-	var start int64
-	var stop int64
-	for i, ref := range []interface{}{&key, &start, &stop} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	start, err := ParseInt(args[1])
+	if err != nil {
+		return nil, errArguments("parse args failed - %s", err)
+	}
+	stop, err := ParseInt(args[1])
+	if err != nil {
+		return nil, errArguments("parse args failed - %s", err)
 	}
 
 	withScore := 1
@@ -1028,12 +996,12 @@ func (s *Store) genericZRange(db uint32, args []interface{}, reverse bool) ([][]
 }
 
 // ZRANGE key start stop [WITHSCORES]
-func (s *Store) ZRange(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) ZRange(db uint32, args [][]byte) ([][]byte, error) {
 	return s.genericZRange(db, args, false)
 }
 
 // ZREVRANGE key start stop [WITHSCORES]
-func (s *Store) ZRevRange(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) ZRevRange(db uint32, args [][]byte) ([][]byte, error) {
 	return s.genericZRange(db, args, true)
 }
 
@@ -1061,19 +1029,14 @@ func sanitizeIndexes(start int64, stop int64, size int64) (int64, int64, int64) 
 	return start, stop, (stop - start) + 1
 }
 
-func (s *Store) genericZRangeBylex(db uint32, args []interface{}, reverse bool) ([][]byte, error) {
+func (s *Store) genericZRangeBylex(db uint32, args [][]byte, reverse bool) ([][]byte, error) {
 	if len(args) != 3 && len(args) != 6 {
 		return nil, errArguments("len(args) = %d, expect = 3 or 6", len(args))
 	}
 
-	var key []byte
-	var min []byte
-	var max []byte
-	for i, ref := range []interface{}{&key, &min, &max} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	min := args[1]
+	max := args[2]
 
 	if reverse {
 		min, max = max, min
@@ -1136,28 +1099,23 @@ func (s *Store) genericZRangeBylex(db uint32, args []interface{}, reverse bool) 
 }
 
 // ZRANGEBYLEX key min max [LIMIT offset count]
-func (s *Store) ZRangeByLex(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) ZRangeByLex(db uint32, args [][]byte) ([][]byte, error) {
 	return s.genericZRangeBylex(db, args, false)
 }
 
 // ZRevRANGEBYLEX key min max [LIMIT offset count]
-func (s *Store) ZRevRangeByLex(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) ZRevRangeByLex(db uint32, args [][]byte) ([][]byte, error) {
 	return s.genericZRangeBylex(db, args, true)
 }
 
-func (s *Store) genericZRangeByScore(db uint32, args []interface{}, reverse bool) ([][]byte, error) {
+func (s *Store) genericZRangeByScore(db uint32, args [][]byte, reverse bool) ([][]byte, error) {
 	if len(args) < 3 {
 		return nil, errArguments("len(args) = %d, expect >= 3", len(args))
 	}
 
-	var key []byte
-	var min []byte
-	var max []byte
-	for i, ref := range []interface{}{&key, &min, &max} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return nil, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	min := args[1]
+	max := args[2]
 
 	if reverse {
 		min, max = max, min
@@ -1233,28 +1191,22 @@ func (s *Store) genericZRangeByScore(db uint32, args []interface{}, reverse bool
 }
 
 // ZRANGEBYSCORE key min max [WITHSCORES] [LIMIT offset count]
-func (s *Store) ZRangeByScore(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) ZRangeByScore(db uint32, args [][]byte) ([][]byte, error) {
 	return s.genericZRangeByScore(db, args, false)
 }
 
 // ZREVRANGEBYSCORE key min max [WITHSCORES] [LIMIT offset count]
-func (s *Store) ZRevRangeByScore(db uint32, args ...interface{}) ([][]byte, error) {
+func (s *Store) ZRevRangeByScore(db uint32, args [][]byte) ([][]byte, error) {
 	return s.genericZRangeByScore(db, args, true)
 }
 
-func (s *Store) genericZRank(db uint32, args []interface{}, reverse bool) (int64, error) {
+func (s *Store) genericZRank(db uint32, args [][]byte, reverse bool) (int64, error) {
 	if len(args) != 2 {
 		return 0, errArguments("len(args) = %d, expect 2", len(args))
 	}
 
-	var key []byte
-	var memeber []byte
-
-	for i, ref := range []interface{}{&key, &memeber} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	member := args[1]
 
 	if err := s.acquire(); err != nil {
 		return 0, err
@@ -1268,7 +1220,7 @@ func (s *Store) genericZRank(db uint32, args []interface{}, reverse bool) (int64
 		return -1, nil
 	}
 
-	o.Member = memeber
+	o.Member = member
 	exists, err := o.LoadDataValue(s)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -1298,30 +1250,24 @@ func (s *Store) genericZRank(db uint32, args []interface{}, reverse bool) (int64
 }
 
 // ZRANK key member
-func (s *Store) ZRank(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZRank(db uint32, args [][]byte) (int64, error) {
 	return s.genericZRank(db, args, false)
 }
 
 // ZREVRANK key member
-func (s *Store) ZRevRank(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZRevRank(db uint32, args [][]byte) (int64, error) {
 	return s.genericZRank(db, args, true)
 }
 
 // ZREMRANGEBYLEX key min max
-func (s *Store) ZRemRangeByLex(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZRemRangeByLex(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect 3", len(args))
 	}
 
-	var key []byte
-	var min []byte
-	var max []byte
-
-	for i, ref := range []interface{}{&key, &min, &max} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	min := args[1]
+	max := args[2]
 
 	r, err := parseLexRangeSpec(min, max)
 	if err != nil {
@@ -1367,19 +1313,19 @@ func (s *Store) ZRemRangeByLex(db uint32, args ...interface{}) (int64, error) {
 }
 
 // ZREMRANGEBYRANK key start stop
-func (s *Store) ZRemRangeByRank(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZRemRangeByRank(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect 3", len(args))
 	}
 
-	var key []byte
-	var start int64
-	var stop int64
-
-	for i, ref := range []interface{}{&key, &start, &stop} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
+	key := args[0]
+	start, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
+	}
+	stop, err := ParseInt(args[1])
+	if err != nil {
+		return 0, errArguments("parse args failed - %s", err)
 	}
 
 	r := &rangeSpec{Min: math.Inf(-1), Max: math.Inf(1), MinEx: true, MaxEx: true}
@@ -1440,20 +1386,14 @@ func (s *Store) ZRemRangeByRank(db uint32, args ...interface{}) (int64, error) {
 }
 
 // ZREMRANGEBYSCORE key min max
-func (s *Store) ZRemRangeByScore(db uint32, args ...interface{}) (int64, error) {
+func (s *Store) ZRemRangeByScore(db uint32, args [][]byte) (int64, error) {
 	if len(args) != 3 {
 		return 0, errArguments("len(args) = %d, expect 3", len(args))
 	}
 
-	var key []byte
-	var min []byte
-	var max []byte
-
-	for i, ref := range []interface{}{&key, &min, &max} {
-		if err := parseArgument(args[i], ref); err != nil {
-			return 0, errArguments("parse args[%d] failed, %s", i, err)
-		}
-	}
+	key := args[0]
+	min := args[1]
+	max := args[2]
 
 	r, err := parseRangeSpec(min, max)
 	if err != nil {

--- a/pkg/store/zset.go
+++ b/pkg/store/zset.go
@@ -935,7 +935,7 @@ func (s *Store) genericZRange(db uint32, args [][]byte, reverse bool) ([][]byte,
 	if err != nil {
 		return nil, errArguments("parse args failed - %s", err)
 	}
-	stop, err := ParseInt(args[1])
+	stop, err := ParseInt(args[2])
 	if err != nil {
 		return nil, errArguments("parse args failed - %s", err)
 	}
@@ -1323,7 +1323,7 @@ func (s *Store) ZRemRangeByRank(db uint32, args [][]byte) (int64, error) {
 	if err != nil {
 		return 0, errArguments("parse args failed - %s", err)
 	}
-	stop, err := ParseInt(args[1])
+	stop, err := ParseInt(args[2])
 	if err != nil {
 		return 0, errArguments("parse args failed - %s", err)
 	}

--- a/pkg/store/zset_test.go
+++ b/pkg/store/zset_test.go
@@ -18,7 +18,7 @@ func (s *testStoreSuite) zdel(c *C, db uint32, key string, expect int64) {
 
 func (s *testStoreSuite) zdump(c *C, db uint32, key string, expect ...interface{}) {
 	s.kexists(c, db, key, 1)
-	v, err := s.s.Dump(db, key)
+	v, err := s.s.Dump(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(v, NotNil)
 
@@ -39,7 +39,7 @@ func (s *testStoreSuite) zdump(c *C, db uint32, key string, expect ...interface{
 	}
 
 	s.zcard(c, db, key, int64(len(m)))
-	p, err := s.s.ZGetAll(db, key)
+	p, err := s.s.ZGetAll(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(len(p), Equals, len(m)*2)
 
@@ -63,7 +63,7 @@ func (s *testStoreSuite) zrestore(c *C, db uint32, key string, ttlms int64, expe
 	dump, err := rdb.EncodeDump(x)
 	c.Assert(err, IsNil)
 
-	err = s.s.Restore(db, key, ttlms, dump)
+	err = s.s.Restore(db, FormatBytes(key, ttlms, dump))
 	c.Assert(err, IsNil)
 
 	s.zdump(c, db, key, expect...)
@@ -75,7 +75,7 @@ func (s *testStoreSuite) zrestore(c *C, db uint32, key string, ttlms int64, expe
 }
 
 func (s *testStoreSuite) zcard(c *C, db uint32, key string, expect int64) {
-	x, err := s.s.ZCard(db, key)
+	x, err := s.s.ZCard(db, FormatBytes(key))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -91,7 +91,7 @@ func (s *testStoreSuite) zrem(c *C, db uint32, key string, expect int64, members
 	for _, m := range members {
 		args = append(args, m)
 	}
-	x, err := s.s.ZRem(db, args...)
+	x, err := s.s.ZRem(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
@@ -102,7 +102,7 @@ func (s *testStoreSuite) zadd(c *C, db uint32, key string, expect int64, pairs .
 		args = append(args, pairs[i+1], pairs[i])
 	}
 
-	x, err := s.s.ZAdd(db, args...)
+	x, err := s.s.ZAdd(db, FormatBytes(args...))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 
@@ -114,26 +114,26 @@ func (s *testStoreSuite) zadd(c *C, db uint32, key string, expect int64, pairs .
 }
 
 func (s *testStoreSuite) zscore(c *C, db uint32, key string, member string, expect float64) {
-	x, ok, err := s.s.ZScore(db, key, member)
+	x, ok, err := s.s.ZScore(db, FormatBytes(key, member))
 	c.Assert(err, IsNil)
 	c.Assert(ok, Equals, true)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) zincrby(c *C, db uint32, key string, member string, delta int64, expect float64) {
-	x, err := s.s.ZIncrBy(db, key, delta, member)
+	x, err := s.s.ZIncrBy(db, FormatBytes(key, delta, member))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) zcount(c *C, db uint32, key string, min string, max string, expect int64) {
-	x, err := s.s.ZCount(db, key, min, max)
+	x, err := s.s.ZCount(db, FormatBytes(key, min, max))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) zlexcount(c *C, db uint32, key string, min string, max string, expect int64) {
-	x, err := s.s.ZLexCount(db, key, min, max)
+	x, err := s.s.ZLexCount(db, FormatBytes(key, min, max))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
@@ -143,9 +143,9 @@ func (s *testStoreSuite) zrange(c *C, db uint32, key string, start int64, stop i
 	var err error
 
 	if !reverse {
-		x, err = s.s.ZRange(db, key, start, stop)
+		x, err = s.s.ZRange(db, FormatBytes(key, start, stop))
 	} else {
-		x, err = s.s.ZRevRange(db, key, start, stop)
+		x, err = s.s.ZRevRange(db, FormatBytes(key, start, stop))
 	}
 
 	c.Assert(err, IsNil)
@@ -160,9 +160,9 @@ func (s *testStoreSuite) zrangebylex(c *C, db uint32, key string, min string, ma
 	var x [][]byte
 	var err error
 	if !reverse {
-		x, err = s.s.ZRangeByLex(db, key, min, max, "LIMIT", offset, count)
+		x, err = s.s.ZRangeByLex(db, FormatBytes(key, min, max, "LIMIT", offset, count))
 	} else {
-		x, err = s.s.ZRevRangeByLex(db, key, min, max, "LIMIT", offset, count)
+		x, err = s.s.ZRevRangeByLex(db, FormatBytes(key, min, max, "LIMIT", offset, count))
 	}
 
 	c.Assert(err, IsNil)
@@ -177,9 +177,9 @@ func (s *testStoreSuite) zrangebyscore(c *C, db uint32, key string, min string, 
 	var x [][]byte
 	var err error
 	if !reverse {
-		x, err = s.s.ZRangeByScore(db, key, min, max, "LIMIT", offset, count)
+		x, err = s.s.ZRangeByScore(db, FormatBytes(key, min, max, "LIMIT", offset, count))
 	} else {
-		x, err = s.s.ZRevRangeByScore(db, key, min, max, "LIMIT", offset, count)
+		x, err = s.s.ZRevRangeByScore(db, FormatBytes(key, min, max, "LIMIT", offset, count))
 
 	}
 
@@ -195,9 +195,9 @@ func (s *testStoreSuite) zrank(c *C, db uint32, key string, member string, rever
 	var x int64
 	var err error
 	if !reverse {
-		x, err = s.s.ZRank(db, key, member)
+		x, err = s.s.ZRank(db, FormatBytes(key, member))
 	} else {
-		x, err = s.s.ZRevRank(db, key, member)
+		x, err = s.s.ZRevRank(db, FormatBytes(key, member))
 	}
 
 	c.Assert(err, IsNil)
@@ -205,19 +205,19 @@ func (s *testStoreSuite) zrank(c *C, db uint32, key string, member string, rever
 }
 
 func (s *testStoreSuite) zremrangebylex(c *C, db uint32, key string, min string, max string, expect int64) {
-	x, err := s.s.ZRemRangeByLex(db, key, min, max)
+	x, err := s.s.ZRemRangeByLex(db, FormatBytes(key, min, max))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) zremrangebyrank(c *C, db uint32, key string, start int64, stop int64, expect int64) {
-	x, err := s.s.ZRemRangeByRank(db, key, start, stop)
+	x, err := s.s.ZRemRangeByRank(db, FormatBytes(key, start, stop))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }
 
 func (s *testStoreSuite) zremrangebyscore(c *C, db uint32, key string, min string, max string, expect int64) {
-	x, err := s.s.ZRemRangeByScore(db, key, min, max)
+	x, err := s.s.ZRemRangeByScore(db, FormatBytes(key, min, max))
 	c.Assert(err, IsNil)
 	c.Assert(x, Equals, expect)
 }


### PR DESCRIPTION
remove iconvert func，now store has used [][]byte instead of ...interface{} as input;
unify expire related variables as int64 except rdb package;
modify test cases