### PR TITLE
Optimize  expired kv del

### DIFF
--- a/pkg/store/hash.go
+++ b/pkg/store/hash.go
@@ -152,8 +152,8 @@ func (o *hashRow) getAllValues(r storeReader) ([][]byte, error) {
 	return values, nil
 }
 
-func (s *Store) loadHashRow(db uint32, key []byte) (*hashRow, error) {
-	o, err := s.loadStoreRow(db, key)
+func (s *Store) loadHashRow(db uint32, key []byte, delExp bool) (*hashRow, error) {
+	o, err := s.loadStoreRow(db, key, delExp)
 	if err != nil {
 		return nil, err
 	} else if o != nil {
@@ -179,7 +179,7 @@ func (s *Store) HGetAll(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (s *Store) HDel(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, true)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -257,7 +257,7 @@ func (s *Store) HExists(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -285,7 +285,7 @@ func (s *Store) HGet(db uint32, args [][]byte) ([]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func (s *Store) HLen(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -337,7 +337,7 @@ func (s *Store) HIncrBy(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -389,7 +389,7 @@ func (s *Store) HIncrByFloat(db uint32, args [][]byte) (float64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -441,7 +441,7 @@ func (s *Store) HKeys(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -461,7 +461,7 @@ func (s *Store) HVals(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (s *Store) HSet(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -531,7 +531,7 @@ func (s *Store) HSetNX(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -581,7 +581,7 @@ func (s *Store) HMSet(db uint32, args [][]byte) error {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, true)
 	if err != nil {
 		return err
 	}
@@ -629,7 +629,7 @@ func (s *Store) HMGet(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadHashRow(db, key)
+	o, err := s.loadHashRow(db, key, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/hash_test.go
+++ b/pkg/store/hash_test.go
@@ -279,7 +279,6 @@ func (s *testStoreSuite) TestHSet(c *C) {
 	s.hgetall(c, 0, "hash", ss...)
 	s.hdelall(c, 0, "hash", 1)
 	s.hgetall(c, 0, "hash")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestHDel(c *C) {
@@ -310,7 +309,6 @@ func (s *testStoreSuite) TestHDel(c *C) {
 		s.hdel(c, 0, "hash", 0, strconv.Itoa(i))
 	}
 	s.hgetall(c, 0, "hash")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestHRestore(c *C) {
@@ -335,7 +333,6 @@ func (s *testStoreSuite) TestHRestore(c *C) {
 	s.hlen(c, 0, "hash", 0)
 	s.kpttl(c, 0, "hash", -2)
 	s.hdelall(c, 0, "hash", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestHIncrBy(c *C) {
@@ -345,7 +342,6 @@ func (s *testStoreSuite) TestHIncrBy(c *C) {
 	s.hincrby(c, 0, "hash", "a", -1000, 0)
 	s.hgetall(c, 0, "hash", "a", "0")
 	s.hdelall(c, 0, "hash", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestHIncrFloat(c *C) {
@@ -362,7 +358,6 @@ func (s *testStoreSuite) TestHIncrFloat(c *C) {
 	c.Assert(err, NotNil)
 
 	s.hdelall(c, 0, "hash", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestHSetNX(c *C) {
@@ -400,7 +395,6 @@ func (s *testStoreSuite) TestHSetNX(c *C) {
 	s.hlen(c, 0, "hash", 3)
 	s.hmget(c, 0, "hash", "0", "x", "1", "c", "2", "a")
 	s.hdelall(c, 0, "hash", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestHMSet(c *C) {
@@ -412,5 +406,4 @@ func (s *testStoreSuite) TestHMSet(c *C) {
 	s.hgetall(c, 0, "hash", "b", "1", "c", "2")
 	s.hdelall(c, 0, "hash", 1)
 	s.hmget(c, 0, "hash", "a", "")
-	s.checkEmpty(c)
 }

--- a/pkg/store/keys.go
+++ b/pkg/store/keys.go
@@ -16,31 +16,46 @@ const (
 	MaxExpireAt = 1e15
 )
 
-func (s *Store) loadStoreRow(db uint32, key []byte) (storeRow, error) {
+func (s *Store) loadStoreRow(db uint32, key []byte, delExp bool) (storeRow, error) {
 	o, err := loadStoreRow(s, db, key)
 	if err != nil || o == nil {
 		return nil, err
 	}
 
-	if s.needDeleteIfExpired() && o.IsExpired() {
-		bt := engine.NewBatch()
-		if err := o.deleteObject(s, bt); err != nil {
-			return nil, err
+	if o.IsExpired() {
+		if delExp {
+			bt := engine.NewBatch()
+			if err := o.deleteObject(s, bt); err != nil {
+				return nil, err
+			}
+			fw := &Forward{DB: db, Op: "Del", Args: [][]byte{key}}
+			return nil, s.commit(bt, fw)
+		} else {
+			m := newItem(db, key)
+			s.sendExpChan(m)
+			return nil, nil
 		}
-		fw := &Forward{DB: db, Op: "Del", Args: [][]byte{key}}
-		return nil, s.commit(bt, fw)
 	}
+
 	return o, nil
 }
 
-func (s *Store) deleteIfExists(bt *engine.Batch, db uint32, key []byte) (bool, error) {
+func (s *Store) checkExpAndDelete(db uint32, key []byte) error {
+	_, err := s.loadStoreRow(db, key, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) checkExistAndDelete(bt *engine.Batch, db uint32, key []byte) (bool, error) {
 	o, err := loadStoreRow(s, db, key)
 	if err != nil || o == nil {
 		return false, err
 	}
-	// if key is already expired, we think it is not exists
-	exists := !o.IsExpired()
-	return exists, o.deleteObject(s, bt)
+
+	return !o.IsExpired(), o.deleteObject(s, bt)
 }
 
 // DEL key [key ...]
@@ -60,7 +75,7 @@ func (s *Store) Del(db uint32, args [][]byte) (int64, error) {
 	bt := engine.NewBatch()
 	for _, key := range keys {
 		if !ms.Has(key) {
-			exists, err := s.deleteIfExists(bt, db, key)
+			exists, err := s.checkExistAndDelete(bt, db, key)
 			if err != nil {
 				return 0, err
 			}
@@ -86,7 +101,7 @@ func (s *Store) Dump(db uint32, args [][]byte) (interface{}, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStoreRow(db, key)
+	o, err := s.loadStoreRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	} else {
@@ -111,7 +126,7 @@ func (s *Store) Type(db uint32, args [][]byte) (ObjectCode, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStoreRow(db, key)
+	o, err := s.loadStoreRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -131,7 +146,7 @@ func (s *Store) Exists(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStoreRow(db, key)
+	o, err := s.loadStoreRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	} else {
@@ -176,7 +191,7 @@ func (s *Store) PTTL(db uint32, args [][]byte) (int64, error) {
 }
 
 func (s *Store) getExpireTTLms(db uint32, key []byte) (int64, error) {
-	o, err := s.loadStoreRow(db, key)
+	o, err := s.loadStoreRow(db, key, false)
 	if err != nil {
 		return 0, err
 	}
@@ -189,7 +204,7 @@ func (s *Store) getExpireTTLms(db uint32, key []byte) (int64, error) {
 }
 
 func (s *Store) setExpireAt(db uint32, key []byte, expireat int64) (int64, error) {
-	o, err := s.loadStoreRow(db, key)
+	o, err := s.loadStoreRow(db, key, true)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -200,7 +215,7 @@ func (s *Store) setExpireAt(db uint32, key []byte, expireat int64) (int64, error
 		fw := &Forward{DB: db, Op: "PExpireAt", Args: [][]byte{key, FormatInt(expireat)}}
 		return 1, s.commit(bt, fw)
 	} else {
-		_, err := s.deleteIfExists(bt, db, key)
+		_, err := s.checkExistAndDelete(bt, db, key)
 		if err != nil {
 			return 0, err
 		}
@@ -222,7 +237,7 @@ func (s *Store) Persist(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStoreRow(db, key)
+	o, err := s.loadStoreRow(db, key, true)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -390,7 +405,7 @@ func (s *Store) Restore(db uint32, args [][]byte) error {
 }
 
 func (s *Store) restore(bt *engine.Batch, db uint32, key []byte, expireat int64, obj interface{}) error {
-	_, err := s.deleteIfExists(bt, db, key)
+	_, err := s.checkExistAndDelete(bt, db, key)
 	if err != nil {
 		return err
 	}

--- a/pkg/store/keys.go
+++ b/pkg/store/keys.go
@@ -96,10 +96,10 @@ func (s *Store) Dump(db uint32, args [][]byte) (interface{}, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStoreRow(db, key, false)
 	if err != nil || o == nil {
@@ -121,10 +121,10 @@ func (s *Store) Type(db uint32, args [][]byte) (ObjectCode, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStoreRow(db, key, false)
 	if err != nil || o == nil {
@@ -141,10 +141,10 @@ func (s *Store) Exists(db uint32, args [][]byte) (int64, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStoreRow(db, key, false)
 	if err != nil || o == nil {
@@ -162,10 +162,10 @@ func (s *Store) TTL(db uint32, args [][]byte) (int64, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	v, err := s.getExpireTTLms(db, key)
 	if err != nil || v < 0 {
@@ -182,10 +182,10 @@ func (s *Store) PTTL(db uint32, args [][]byte) (int64, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	return s.getExpireTTLms(db, key)
 }

--- a/pkg/store/keys_test.go
+++ b/pkg/store/keys_test.go
@@ -140,7 +140,6 @@ func (s *testStoreSuite) TestDel(c *C) {
 	s.kdel(c, 0, 2, "a", "b", "c", "d")
 	s.xset(c, 0, "a", "a")
 	s.kdel(c, 0, 1, "a", "a")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestExists(c *C) {
@@ -149,7 +148,6 @@ func (s *testStoreSuite) TestExists(c *C) {
 	s.kexists(c, 0, "a", 1)
 	s.kdel(c, 0, 1, "a")
 	s.kexists(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestTTL(c *C) {
@@ -172,7 +170,6 @@ func (s *testStoreSuite) TestTTL(c *C) {
 	sleepms(200)
 	s.kttl(c, 0, "a", -2)
 	s.kexists(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestPTTL(c *C) {
@@ -191,7 +188,6 @@ func (s *testStoreSuite) TestPTTL(c *C) {
 	sleepms(200)
 	s.kpttl(c, 0, "a", -2)
 	s.kexists(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestPersist(c *C) {
@@ -204,7 +200,6 @@ func (s *testStoreSuite) TestPersist(c *C) {
 	sleepms(200)
 	s.kpersist(c, 0, "a", 0)
 	s.kexists(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestExpire(c *C) {
@@ -219,7 +214,6 @@ func (s *testStoreSuite) TestExpire(c *C) {
 
 	s.kexpireat(c, 0, "a", 0, 1)
 	s.ktype(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestPExpire(c *C) {
@@ -232,7 +226,6 @@ func (s *testStoreSuite) TestPExpire(c *C) {
 	s.kpexpire(c, 0, "a", 100, 1)
 	sleepms(200)
 	s.ktype(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestExpireAt(c *C) {
@@ -247,7 +240,6 @@ func (s *testStoreSuite) TestExpireAt(c *C) {
 	s.xset(c, 0, "a", "a")
 	s.kexpireat(c, 0, "a", 0, 1)
 	s.kexists(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestPExpireAt(c *C) {
@@ -262,7 +254,6 @@ func (s *testStoreSuite) TestPExpireAt(c *C) {
 	s.xset(c, 0, "a", "a")
 	s.kpexpireat(c, 0, "a", 0, 1)
 	s.kexists(c, 0, "a", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestRestore(c *C) {
@@ -274,5 +265,4 @@ func (s *testStoreSuite) TestRestore(c *C) {
 	s.srestore(c, 0, "key", 10, "a", "b", "c", "d")
 	sleepms(30)
 	s.kexists(c, 0, "key", 0)
-	s.checkEmpty(c)
 }

--- a/pkg/store/list.go
+++ b/pkg/store/list.go
@@ -86,8 +86,8 @@ func (o *listRow) loadObjectValue(r storeReader) (interface{}, error) {
 	return rdb.List(list), nil
 }
 
-func (s *Store) loadListRow(db uint32, key []byte) (*listRow, error) {
-	o, err := s.loadStoreRow(db, key)
+func (s *Store) loadListRow(db uint32, key []byte, delExp bool) (*listRow, error) {
+	o, err := s.loadStoreRow(db, key, delExp)
 	if err != nil {
 		return nil, err
 	} else if o != nil {
@@ -112,7 +112,7 @@ func (s *Store) LIndex(db uint32, args [][]byte) ([]byte, error) {
 		return nil, errArguments("parse args failed - %s", err)
 	}
 
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (s *Store) LLen(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -170,7 +170,7 @@ func (s *Store) LRange(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (s *Store) LSet(db uint32, args [][]byte) error {
 	}
 	defer s.release()
 
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, true)
 	if err != nil {
 		return err
 	}
@@ -252,7 +252,7 @@ func (s *Store) LTrim(db uint32, args [][]byte) error {
 	}
 	defer s.release()
 
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, true)
 	if err != nil || o == nil {
 		return err
 	}
@@ -296,7 +296,7 @@ func (s *Store) LPop(db uint32, args [][]byte) ([]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, true)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (s *Store) RPop(db uint32, args [][]byte) ([]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, true)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (s *Store) RPushX(db uint32, args [][]byte) (int64, error) {
 }
 
 func (s *Store) lpush(db uint32, key []byte, create bool, values ...[]byte) (int64, error) {
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -445,7 +445,7 @@ func (s *Store) lpush(db uint32, key []byte, create bool, values ...[]byte) (int
 }
 
 func (s *Store) rpush(db uint32, key []byte, create bool, values ...[]byte) (int64, error) {
-	o, err := s.loadListRow(db, key)
+	o, err := s.loadListRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/store/list.go
+++ b/pkg/store/list.go
@@ -112,6 +112,11 @@ func (s *Store) LIndex(db uint32, args [][]byte) ([]byte, error) {
 		return nil, errArguments("parse args failed - %s", err)
 	}
 
+	if err := s.acquireRead(); err != nil {
+		return nil, err
+	}
+	defer s.releaseRead()
+
 	o, err := s.loadListRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
@@ -137,10 +142,10 @@ func (s *Store) LLen(db uint32, args [][]byte) (int64, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadListRow(db, key, false)
 	if err != nil || o == nil {
@@ -165,10 +170,10 @@ func (s *Store) LRange(db uint32, args [][]byte) ([][]byte, error) {
 		return nil, errArguments("parse args failed - %s", err)
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadListRow(db, key, false)
 	if err != nil || o == nil {

--- a/pkg/store/list_test.go
+++ b/pkg/store/list_test.go
@@ -178,7 +178,6 @@ func (s *testStoreSuite) TestLRestore(c *C) {
 	s.kpttl(c, 0, "list", -2)
 	s.llen(c, 0, "list", 0)
 	s.ldel(c, 0, "list", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestLIndex(c *C) {
@@ -204,7 +203,6 @@ func (s *testStoreSuite) TestLIndex(c *C) {
 	for i := -4; i <= 4; i++ {
 		s.lindex(c, 0, "list", i, "")
 	}
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestLRange(c *C) {
@@ -223,7 +221,6 @@ func (s *testStoreSuite) TestLRange(c *C) {
 	s.lrange(c, 0, "list", -1000, 1000, "a", "b", "c", "d")
 	s.llen(c, 0, "list", 4)
 	s.ldel(c, 0, "list", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestRPush(c *C) {
@@ -249,7 +246,6 @@ func (s *testStoreSuite) TestRPush(c *C) {
 	s.rpushx(c, 0, "list", "world", 0)
 	s.llen(c, 0, "list", 0)
 	s.kexists(c, 0, "list", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestLPush(c *C) {
@@ -278,7 +274,6 @@ func (s *testStoreSuite) TestLPush(c *C) {
 	s.lpushx(c, 0, "list", "world", 0)
 	s.llen(c, 0, "list", 0)
 	s.kexists(c, 0, "list", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestLPop(c *C) {
@@ -291,7 +286,6 @@ func (s *testStoreSuite) TestLPop(c *C) {
 	s.lpop(c, 0, "list", "x")
 	s.lpop(c, 0, "list", "d")
 	s.lpop(c, 0, "list", "")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestRPop(c *C) {
@@ -304,7 +298,6 @@ func (s *testStoreSuite) TestRPop(c *C) {
 	s.rpop(c, 0, "list", "x")
 	s.rpop(c, 0, "list", "d")
 	s.rpop(c, 0, "list", "")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestLSet(c *C) {
@@ -322,7 +315,6 @@ func (s *testStoreSuite) TestLSet(c *C) {
 	s.ldump(c, 0, "list", ss...)
 	s.ltrim(c, 0, "list", 1, 0)
 	s.ldel(c, 0, "list", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestLTrim(c *C) {
@@ -354,5 +346,4 @@ func (s *testStoreSuite) TestLTrim(c *C) {
 	s.ldump(c, 0, "list", ss...)
 	s.ltrim(c, 0, "list", 2, 1)
 	s.llen(c, 0, "list", 0)
-	s.checkEmpty(c)
 }

--- a/pkg/store/set.go
+++ b/pkg/store/set.go
@@ -192,10 +192,10 @@ func (s *Store) SCard(db uint32, args [][]byte) (int64, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {
@@ -213,10 +213,10 @@ func (s *Store) SIsMember(db uint32, args [][]byte) (int64, error) {
 	key := args[0]
 	member := args[1]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {
@@ -240,10 +240,10 @@ func (s *Store) SMembers(db uint32, args [][]byte) ([][]byte, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {
@@ -305,10 +305,10 @@ func (s *Store) SRandMember(db uint32, args [][]byte) ([][]byte, error) {
 		}
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {

--- a/pkg/store/set.go
+++ b/pkg/store/set.go
@@ -125,8 +125,8 @@ func (o *setRow) getMembers(r storeReader, count int64) ([][]byte, error) {
 	return members, nil
 }
 
-func (s *Store) loadSetRow(db uint32, key []byte) (*setRow, error) {
-	o, err := s.loadStoreRow(db, key)
+func (s *Store) loadSetRow(db uint32, key []byte, delExp bool) (*setRow, error) {
+	o, err := s.loadStoreRow(db, key, delExp)
 	if err != nil {
 		return nil, err
 	} else if o != nil {
@@ -153,7 +153,7 @@ func (s *Store) SAdd(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadSetRow(db, key)
+	o, err := s.loadSetRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -197,7 +197,7 @@ func (s *Store) SCard(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadSetRow(db, key)
+	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -218,7 +218,7 @@ func (s *Store) SIsMember(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadSetRow(db, key)
+	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -245,7 +245,7 @@ func (s *Store) SMembers(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadSetRow(db, key)
+	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (s *Store) SPop(db uint32, args [][]byte) ([]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadSetRow(db, key)
+	o, err := s.loadSetRow(db, key, true)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (s *Store) SRandMember(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadSetRow(db, key)
+	o, err := s.loadSetRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -339,7 +339,7 @@ func (s *Store) SRem(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadSetRow(db, key)
+	o, err := s.loadSetRow(db, key, true)
 	if err != nil || o == nil {
 		return 0, err
 	}

--- a/pkg/store/set_test.go
+++ b/pkg/store/set_test.go
@@ -157,7 +157,6 @@ func (s *testStoreSuite) TestSRestore(c *C) {
 	sleepms(200)
 	s.scard(c, 0, "set", 0)
 	s.kpttl(c, 0, "set", -2)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSAdd(c *C) {
@@ -176,7 +175,6 @@ func (s *testStoreSuite) TestSAdd(c *C) {
 	s.sadd(c, 0, "set", 0, "0", "1", "2", "3")
 	s.sdel(c, 0, "set", 1)
 	s.sdel(c, 0, "set", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSMembers(c *C) {
@@ -186,7 +184,6 @@ func (s *testStoreSuite) TestSMembers(c *C) {
 	sleepms(200)
 	s.smembers(c, 0, "set")
 	s.kpexpire(c, 0, "set", 10, 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSRem(c *C) {
@@ -199,7 +196,6 @@ func (s *testStoreSuite) TestSRem(c *C) {
 	s.srem(c, 0, "set", 2, "1", "2")
 	s.scard(c, 0, "set", 0)
 	s.kpttl(c, 0, "set", -2)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSPop(c *C) {
@@ -210,7 +206,6 @@ func (s *testStoreSuite) TestSPop(c *C) {
 		s.spop(c, 0, "set", 1)
 	}
 	s.spop(c, 0, "set", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSRandMember(c *C) {
@@ -225,5 +220,4 @@ func (s *testStoreSuite) TestSRandMember(c *C) {
 		s.srandpop(c, 0, "set", 1)
 	}
 	s.scard(c, 0, "set", 0)
-	s.checkEmpty(c)
 }

--- a/pkg/store/slots_test.go
+++ b/pkg/store/slots_test.go
@@ -269,7 +269,6 @@ func (s *testStoreSuite) TestSlotsRestore(c *C) {
 	s.slotsinfo(c, 0, 1)
 	s.xdel(c, 0, "key", 1)
 	s.slotsinfo(c, 0, 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSlotsMgrtSlot(c *C) {
@@ -295,7 +294,6 @@ func (s *testStoreSuite) TestSlotsMgrtSlot(c *C) {
 	s.checkSlotsMgrt(c, r, w, s.slotsmgrtslot(addr, 1, "key", 1), "key", 0, "world2")
 	s.slotsinfo(c, 1, 0)
 
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSlotsMgrtTagSlot(c *C) {
@@ -319,7 +317,6 @@ func (s *testStoreSuite) TestSlotsMgrtTagSlot(c *C) {
 	s.checkSlotsMgrt(c, r, w, s.slotsmgrttagslot(addr, 0, "", 0))
 	s.slotsinfo(c, 0, 0)
 
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSlotsMgrtOne(c *C) {
@@ -342,7 +339,6 @@ func (s *testStoreSuite) TestSlotsMgrtOne(c *C) {
 	s.checkSlotsMgrt(c, r, w, s.slotsmgrtone(addr, 1, "key{tag}2", 1), "key{tag}2", 0, "world")
 	s.slotsinfo(c, 1, 0)
 
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestSlotsMgrtTagOne(c *C) {
@@ -373,5 +369,4 @@ func (s *testStoreSuite) TestSlotsMgrtTagOne(c *C) {
 	s.checkSlotsMgrt(c, r, w, s.slotsmgrttagone(addr, 2, "key{tag}3", 0))
 	s.xdel(c, 2, "key{tag3}", 0)
 
-	s.checkEmpty(c)
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -42,12 +42,12 @@ func (s *testStoreSuite) checkCompact(c *C) {
 }
 
 func (s *testStoreSuite) checkEmpty(c *C) {
-	it := s.s.getIterator()
-	defer s.s.putIterator(it)
+	// it := s.s.getIterator()
+	// defer s.s.putIterator(it)
 
-	it.SeekToFirst()
-	c.Assert(it.Error(), IsNil)
-	c.Assert(it.Valid(), Equals, false)
+	// it.SeekToFirst()
+	// c.Assert(it.Error(), IsNil)
+	// c.Assert(it.Valid(), Equals, false)
 }
 
 func testCreateStore(c *C) *Store {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -42,12 +42,12 @@ func (s *testStoreSuite) checkCompact(c *C) {
 }
 
 func (s *testStoreSuite) checkEmpty(c *C) {
-	// it := s.s.getIterator()
-	// defer s.s.putIterator(it)
+	it := s.s.getIterator()
+	defer s.s.putIterator(it)
 
-	// it.SeekToFirst()
-	// c.Assert(it.Error(), IsNil)
-	// c.Assert(it.Valid(), Equals, false)
+	it.SeekToFirst()
+	c.Assert(it.Error(), IsNil)
+	c.Assert(it.Valid(), Equals, false)
 }
 
 func testCreateStore(c *C) *Store {

--- a/pkg/store/string.go
+++ b/pkg/store/string.go
@@ -135,10 +135,10 @@ func (s *Store) Get(db uint32, args [][]byte) ([]byte, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStringRow(db, key, false)
 	if err != nil || o == nil {
@@ -730,10 +730,10 @@ func (s *Store) MGet(db uint32, args [][]byte) ([][]byte, error) {
 
 	keys := args
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	values := make([][]byte, len(keys))
 	for i, key := range keys {
@@ -770,10 +770,10 @@ func (s *Store) GetBit(db uint32, args [][]byte) (int64, error) {
 		return 0, errArguments("bit offset is not an integer or out of range, offset=%d", offset)
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStringRow(db, key, false)
 	if err != nil || o == nil {
@@ -815,10 +815,10 @@ func (s *Store) GetRange(db uint32, args [][]byte) ([]byte, error) {
 		return nil, errArguments("parse args failed - %s", err)
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStringRow(db, key, false)
 	if err != nil {
@@ -850,10 +850,10 @@ func (s *Store) Strlen(db uint32, args [][]byte) (int64, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStringRow(db, key, false)
 	if err != nil {
@@ -894,10 +894,10 @@ func (s *Store) BitCount(db uint32, args [][]byte) (int64, error) {
 		}
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadStringRow(db, key, false)
 	if err != nil {

--- a/pkg/store/string.go
+++ b/pkg/store/string.go
@@ -113,8 +113,8 @@ func (o *stringRow) loadObjectValue(r storeReader) (interface{}, error) {
 	return rdb.String(o.Value), nil
 }
 
-func (s *Store) loadStringRow(db uint32, key []byte) (*stringRow, error) {
-	o, err := s.loadStoreRow(db, key)
+func (s *Store) loadStringRow(db uint32, key []byte, delExp bool) (*stringRow, error) {
+	o, err := s.loadStoreRow(db, key, delExp)
 	if err != nil {
 		return nil, err
 	} else if o != nil {
@@ -140,7 +140,7 @@ func (s *Store) Get(db uint32, args [][]byte) ([]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	} else {
@@ -167,7 +167,7 @@ func (s *Store) Append(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -352,7 +352,7 @@ func (s *Store) GetSet(db uint32, args [][]byte) ([]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, true)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (s *Store) GetSet(db uint32, args [][]byte) ([]byte, error) {
 }
 
 func (s *Store) incrInt(db uint32, key []byte, delta int64) (int64, error) {
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -410,7 +410,7 @@ func (s *Store) incrInt(db uint32, key []byte, delta int64) (int64, error) {
 }
 
 func (s *Store) incrFloat(db uint32, key []byte, delta float64) (float64, error) {
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -563,7 +563,7 @@ func (s *Store) SetBit(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -627,7 +627,7 @@ func (s *Store) SetRange(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -670,10 +670,11 @@ func (s *Store) MSet(db uint32, args [][]byte) error {
 	for i := len(args)/2 - 1; i >= 0; i-- {
 		key, value := args[i*2], args[i*2+1]
 		if !ms.Has(key) {
-			_, err := s.deleteIfExists(bt, db, key)
+			_, err := s.checkExistAndDelete(bt, db, key)
 			if err != nil {
 				return err
 			}
+
 			o := newStringRow(db, key)
 			o.Value = value
 			bt.Set(o.DataKey(), o.DataValue())
@@ -698,7 +699,7 @@ func (s *Store) MSetNX(db uint32, args [][]byte) (int64, error) {
 	defer s.release()
 
 	for i := 0; i < len(args); i += 2 {
-		o, err := s.loadStoreRow(db, args[i])
+		o, err := s.loadStoreRow(db, args[i], true)
 		if err != nil || o != nil {
 			return 0, err
 		}
@@ -736,7 +737,7 @@ func (s *Store) MGet(db uint32, args [][]byte) ([][]byte, error) {
 
 	values := make([][]byte, len(keys))
 	for i, key := range keys {
-		o, err := s.loadStringRow(db, key)
+		o, err := s.loadStringRow(db, key, false)
 		if err != nil {
 			return nil, err
 		}
@@ -774,7 +775,7 @@ func (s *Store) GetBit(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -819,7 +820,7 @@ func (s *Store) GetRange(db uint32, args [][]byte) ([]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, false)
 	if err != nil {
 		return nil, err
 	}
@@ -854,7 +855,7 @@ func (s *Store) Strlen(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, false)
 	if err != nil {
 		return 0, err
 	}
@@ -898,7 +899,7 @@ func (s *Store) BitCount(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadStringRow(db, key)
+	o, err := s.loadStringRow(db, key, false)
 	if err != nil {
 		return 0, err
 	}
@@ -953,7 +954,7 @@ func (s *Store) BitOp(db uint32, args [][]byte) (int64, error) {
 	defer s.release()
 
 	var value []byte
-	o, err := s.loadStringRow(db, srcKeys[0])
+	o, err := s.loadStringRow(db, srcKeys[0], true)
 	if err != nil {
 		return 0, err
 	}
@@ -974,7 +975,7 @@ func (s *Store) BitOp(db uint32, args [][]byte) (int64, error) {
 	}
 
 	for i := 1; i < len(srcKeys); i++ {
-		ro, err := s.loadStringRow(db, srcKeys[i])
+		ro, err := s.loadStringRow(db, srcKeys[i], true)
 		if err != nil {
 			return 0, err
 		}
@@ -1019,7 +1020,7 @@ func (s *Store) BitOp(db uint32, args [][]byte) (int64, error) {
 
 	bt := engine.NewBatch()
 
-	_, err = s.deleteIfExists(bt, db, destKey)
+	_, err = s.checkExistAndDelete(bt, db, destKey)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/store/string_test.go
+++ b/pkg/store/string_test.go
@@ -284,7 +284,6 @@ func (s *testStoreSuite) TestXRestore(c *C) {
 	s.xget(c, 0, "string", "test")
 	sleepms(200)
 	s.xget(c, 0, "string", "")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXSet(c *C) {
@@ -318,7 +317,6 @@ func (s *testStoreSuite) TestXSet(c *C) {
 	sleepms(2000)
 	s.kpttl(c, 0, "string", -2)
 
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXAppend(c *C) {
@@ -346,7 +344,6 @@ func (s *testStoreSuite) TestXAppend(c *C) {
 	}
 	s.xdump(c, 0, "string", expect)
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXSetEX(c *C) {
@@ -360,7 +357,6 @@ func (s *testStoreSuite) TestXSetEX(c *C) {
 	s.xget(c, 0, "string", "world")
 	s.kpttl(c, 0, "string", 100000)
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXPSetEX(c *C) {
@@ -369,7 +365,6 @@ func (s *testStoreSuite) TestXPSetEX(c *C) {
 	s.xpsetex(c, 0, "string", "world", 2000)
 	s.kpttl(c, 0, "string", 2000)
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXSetNX(c *C) {
@@ -382,7 +377,6 @@ func (s *testStoreSuite) TestXSetNX(c *C) {
 	s.xsetnx(c, 0, "string", "world", 1)
 	s.xdel(c, 0, "string", 1)
 	s.xdel(c, 0, "string", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXGetSet(c *C) {
@@ -395,7 +389,6 @@ func (s *testStoreSuite) TestXGetSet(c *C) {
 	s.kpttl(c, 0, "string", -1)
 
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXIncrDecr(c *C) {
@@ -410,7 +403,6 @@ func (s *testStoreSuite) TestXIncrDecr(c *C) {
 	}
 	s.xget(c, 0, "string", "0")
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXIncrBy(c *C) {
@@ -427,7 +419,6 @@ func (s *testStoreSuite) TestXIncrBy(c *C) {
 	}
 	s.xget(c, 0, "string", strconv.Itoa(int(sum)))
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 
 }
 
@@ -446,7 +437,6 @@ func (s *testStoreSuite) TestXIncrByFloat(c *C) {
 	c.Assert(err, NotNil)
 
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXSetBit(c *C) {
@@ -489,7 +479,6 @@ func (s *testStoreSuite) TestXSetBit(c *C) {
 	s.xsetbit(c, 0, "string", 16, 0, 0)
 	s.xget(c, 0, "string", "\x00\x00\x00")
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXSetRange(c *C) {
@@ -500,7 +489,6 @@ func (s *testStoreSuite) TestXSetRange(c *C) {
 	s.xsetrange(c, 0, "string", 2, "test1test2test3", 17)
 	s.xget(c, 0, "string", "\x00htest1test2test3")
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestGetBit(c *C) {
@@ -525,7 +513,6 @@ func (s *testStoreSuite) TestGetBit(c *C) {
 		s.xgetbit(c, 0, "string", uint(i), v)
 	}
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestGetRange(c *C) {
@@ -543,7 +530,6 @@ func (s *testStoreSuite) TestGetRange(c *C) {
 	s.xgetrange(c, 0, "string", -1, -1000, "")
 	s.xgetrange(c, 0, "string", -100, 100, "hello world!!")
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestXMSet(c *C) {
@@ -559,7 +545,6 @@ func (s *testStoreSuite) TestXMSet(c *C) {
 
 	s.xmset(c, 0, "a", "1", "a", "2", "a", "3", "b", "1", "b", "2")
 	s.kdel(c, 0, 3, "a", "b", "c")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestMSetNX(c *C) {
@@ -583,7 +568,6 @@ func (s *testStoreSuite) TestMSetNX(c *C) {
 	s.xmsetnx(c, 0, 1, "string", "hello", "string", "world")
 	s.xget(c, 0, "string", "world")
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestMGet(c *C) {
@@ -593,7 +577,6 @@ func (s *testStoreSuite) TestMGet(c *C) {
 
 	s.xmget(c, 0, "a", "", "b", "2", "c", "3", "d", "")
 	s.kdel(c, 0, 2, "a", "b", "c")
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestBitCount(c *C) {
@@ -621,7 +604,6 @@ func (s *testStoreSuite) TestBitCount(c *C) {
 	s.xbitcount(c, 0, 4, "string", 0, -1)
 
 	s.xdel(c, 0, "string", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestBitOp(c *C) {
@@ -655,5 +637,4 @@ func (s *testStoreSuite) TestBitOp(c *C) {
 	s.xdel(c, 0, "a", 1)
 	s.xdel(c, 0, "b", 1)
 	s.xdel(c, 0, "c", 1)
-	s.checkEmpty(c)
 }

--- a/pkg/store/zset.go
+++ b/pkg/store/zset.go
@@ -218,10 +218,10 @@ func (s *Store) ZGetAll(db uint32, args [][]byte) ([][]byte, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil || o == nil {
@@ -249,10 +249,10 @@ func (s *Store) ZCard(db uint32, args [][]byte) (int64, error) {
 
 	key := args[0]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil || o == nil {
@@ -388,10 +388,10 @@ func (s *Store) ZScore(db uint32, args [][]byte) (float64, bool, error) {
 	key := args[0]
 	member := args[1]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, false, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil || o == nil {
@@ -646,10 +646,10 @@ func (s *Store) ZCount(db uint32, args [][]byte) (int64, error) {
 		return 0, errors.Trace(err)
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
@@ -903,10 +903,10 @@ func (s *Store) ZLexCount(db uint32, args [][]byte) (int64, error) {
 		return 0, errors.Trace(err)
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
@@ -949,10 +949,10 @@ func (s *Store) genericZRange(db uint32, args [][]byte, reverse bool) ([][]byte,
 		withScore = 2
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
@@ -1063,10 +1063,10 @@ func (s *Store) genericZRangeBylex(db uint32, args [][]byte, reverse bool) ([][]
 		return nil, errors.Trace(err)
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
@@ -1172,10 +1172,10 @@ func (s *Store) genericZRangeByScore(db uint32, args [][]byte, reverse bool) ([]
 		return nil
 	}
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return nil, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
@@ -1209,10 +1209,10 @@ func (s *Store) genericZRank(db uint32, args [][]byte, reverse bool) (int64, err
 	key := args[0]
 	member := args[1]
 
-	if err := s.acquire(); err != nil {
+	if err := s.acquireRead(); err != nil {
 		return 0, err
 	}
-	defer s.release()
+	defer s.releaseRead()
 
 	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
@@ -1280,7 +1280,7 @@ func (s *Store) ZRemRangeByLex(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key, false)
+	o, err := s.loadZSetRow(db, key, true)
 	if err != nil {
 		return 0, err
 	} else if o == nil {

--- a/pkg/store/zset.go
+++ b/pkg/store/zset.go
@@ -196,8 +196,8 @@ func (o *zsetRow) loadObjectValue(r storeReader) (interface{}, error) {
 	return rdb.ZSet(zset), nil
 }
 
-func (s *Store) loadZSetRow(db uint32, key []byte) (*zsetRow, error) {
-	o, err := s.loadStoreRow(db, key)
+func (s *Store) loadZSetRow(db uint32, key []byte, delExp bool) (*zsetRow, error) {
+	o, err := s.loadStoreRow(db, key, delExp)
 	if err != nil {
 		return nil, err
 	} else if o != nil {
@@ -223,7 +223,7 @@ func (s *Store) ZGetAll(db uint32, args [][]byte) ([][]byte, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (s *Store) ZCard(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -293,7 +293,7 @@ func (s *Store) ZAdd(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -346,7 +346,7 @@ func (s *Store) ZRem(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, true)
 	if err != nil || o == nil {
 		return 0, err
 	}
@@ -393,7 +393,7 @@ func (s *Store) ZScore(db uint32, args [][]byte) (float64, bool, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil || o == nil {
 		return 0, false, err
 	}
@@ -425,7 +425,7 @@ func (s *Store) ZIncrBy(db uint32, args [][]byte) (float64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, true)
 	if err != nil {
 		return 0, err
 	}
@@ -651,7 +651,7 @@ func (s *Store) ZCount(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
 		return 0, err
 	}
@@ -908,7 +908,7 @@ func (s *Store) ZLexCount(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
 		return 0, err
 	}
@@ -954,7 +954,7 @@ func (s *Store) genericZRange(db uint32, args [][]byte, reverse bool) ([][]byte,
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1068,7 +1068,7 @@ func (s *Store) genericZRangeBylex(db uint32, args [][]byte, reverse bool) ([][]
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1177,7 +1177,7 @@ func (s *Store) genericZRangeByScore(db uint32, args [][]byte, reverse bool) ([]
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1214,7 +1214,7 @@ func (s *Store) genericZRank(db uint32, args [][]byte, reverse bool) (int64, err
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
 		return 0, err
 	} else if o == nil {
@@ -1280,7 +1280,7 @@ func (s *Store) ZRemRangeByLex(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, false)
 	if err != nil {
 		return 0, err
 	} else if o == nil {
@@ -1336,7 +1336,7 @@ func (s *Store) ZRemRangeByRank(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, true)
 	if err != nil {
 		return 0, err
 	} else if o == nil {
@@ -1406,7 +1406,7 @@ func (s *Store) ZRemRangeByScore(db uint32, args [][]byte) (int64, error) {
 	}
 	defer s.release()
 
-	o, err := s.loadZSetRow(db, key)
+	o, err := s.loadZSetRow(db, key, true)
 	if err != nil {
 		return 0, err
 	} else if o == nil {

--- a/pkg/store/zset_test.go
+++ b/pkg/store/zset_test.go
@@ -236,7 +236,6 @@ func (s *testStoreSuite) TestZAdd(c *C) {
 	s.kpexpire(c, 0, "zset", 10, 1)
 	sleepms(20)
 	s.zdel(c, 0, "zset", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRem(c *C) {
@@ -249,7 +248,6 @@ func (s *testStoreSuite) TestZRem(c *C) {
 	}
 	s.zrem(c, 0, "zset", 32, append(m, m...)...)
 	s.zcard(c, 0, "zset", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZIncrBy(c *C) {
@@ -259,7 +257,6 @@ func (s *testStoreSuite) TestZIncrBy(c *C) {
 	s.zincrby(c, 0, "zset", "a", 1000, 1000)
 	s.zcard(c, 0, "zset", 1)
 	s.zdel(c, 0, "zset", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRestore(c *C) {
@@ -279,7 +276,6 @@ func (s *testStoreSuite) TestZRestore(c *C) {
 	sleepms(200)
 	s.kpttl(c, 0, "zset", -2)
 	s.zdel(c, 0, "zset", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZCount(c *C) {
@@ -307,7 +303,6 @@ func (s *testStoreSuite) TestZCount(c *C) {
 	s.zcount(c, 0, "zset", "-inf", "-inf", 0)
 
 	s.zdel(c, 0, "zset", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZLexCount(c *C) {
@@ -331,7 +326,6 @@ func (s *testStoreSuite) TestZLexCount(c *C) {
 	s.zlexcount(c, 0, "zset", "-", "-", 0)
 
 	s.zdel(c, 0, "zset", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRange(c *C) {
@@ -351,7 +345,6 @@ func (s *testStoreSuite) TestZRange(c *C) {
 
 	s.zdel(c, 0, "zset", 1)
 	s.zdel(c, 0, "zseu", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRangeByLex(c *C) {
@@ -374,7 +367,6 @@ func (s *testStoreSuite) TestZRangeByLex(c *C) {
 	s.zrangebylex(c, 0, "zset", "(g", "[aaa", 1, -1, true, "e", "d", "c", "b")
 
 	s.zdel(c, 0, "zset", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRangeByScore(c *C) {
@@ -397,7 +389,6 @@ func (s *testStoreSuite) TestZRangeByScore(c *C) {
 	s.zrangebyscore(c, 0, "zset", "(2.2", "(1.1", 0, -1, true)
 
 	s.zdel(c, 0, "zset", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRank(c *C) {
@@ -421,7 +412,6 @@ func (s *testStoreSuite) TestZRank(c *C) {
 	s.zrank(c, 0, "zset", "abc", true, -1)
 
 	s.zdel(c, 0, "zset", 1)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRemRangeByLex(c *C) {
@@ -440,7 +430,6 @@ func (s *testStoreSuite) TestZRemRangeByLex(c *C) {
 	s.zcard(c, 0, "zset", 0)
 
 	s.zdel(c, 0, "zset", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRemRangeByRank(c *C) {
@@ -460,7 +449,6 @@ func (s *testStoreSuite) TestZRemRangeByRank(c *C) {
 	s.zcard(c, 0, "zset", 0)
 
 	s.zdel(c, 0, "zset", 0)
-	s.checkEmpty(c)
 }
 
 func (s *testStoreSuite) TestZRemRangeByScore(c *C) {
@@ -480,5 +468,4 @@ func (s *testStoreSuite) TestZRemRangeByScore(c *C) {
 	s.zcard(c, 0, "zset", 0)
 
 	s.zdel(c, 0, "zset", 0)
-	s.checkEmpty(c)
 }


### PR DESCRIPTION
1 use channel for expired value del
2 use read lock for readonly cmd
3 remove checkEmpty in test because lazy del cause it fail sometimes