### PR TITLE
fix psync bug

### DIFF
--- a/pkg/service/sync.go
+++ b/pkg/service/sync.go
@@ -458,6 +458,7 @@ func (h *Handler) startSyncFromMaster(c *conn, size int64) error {
 		h.masterConnState.Set(masterConnSync)
 		log.Infof("sync rdb file size = %d bytes\n", size)
 		if err := h.doSyncRDB(c, size); err != nil {
+			h.syncOffset.Set(-1) //we need fullsync when sync rdb faild
 			return errors.Trace(err)
 		}
 		log.Infof("sync rdb done")


### PR DESCRIPTION
如果syncRdb出错，slave重连的时候需要重新fullsync（重新syncRdb，而不是只sync back_log，否则会丢掉syncRdb出差时还没sync完的）。
